### PR TITLE
feat: implement GAM.bic(), null_deviance(), r_squared()

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,19 @@
+2026-04-25 : Cleanup follow-ups
+- Categorical predict() now emits a UserWarning naming any categories
+  not seen during fit (effect 0 fallback is unchanged).
+- Harden the Newton iterations in _prox_binomial_logit_scalar and
+  _prox_poisson_log_scalar: switch to scipy.special.expit /
+  np.logaddexp for stability, add a backtracking line search, and
+  fall back to scipy.optimize.minimize_scalar instead of raising
+  ValueError when max_its is exhausted.
+- Add GAM.residuals(kind="response"|"pearson"|"deviance") and
+  GAM.plot_residuals(): a 1x2 figure with residuals-vs-fitted on the
+  left and a normal Q-Q plot on the right.
+- Implement Poisson overdispersion: GAM(family="poisson",
+  estimate_overdispersion=True) now estimates phi via the Pearson
+  chi-square / dof formula. Without the flag the dispersion is still
+  fixed at 1.0.
+
 2026-04-25 : BIC and pseudo-R^2
 - Add GAM.bic() = deviance/dispersion + log(n) * p, matching the
   parameter-counting convention used by aic()/aicc().

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,15 @@
+2026-04-25 : BIC and pseudo-R^2
+- Add GAM.bic() = deviance/dispersion + log(n) * p, matching the
+  parameter-counting convention used by aic()/aicc().
+- Add GAM.null_deviance() (deviance of the intercept-only model) and
+  GAM.r_squared() (deviance-based pseudo-R^2; classical R^2 for the
+  normal+identity case, NaN when null deviance is zero).
+- Refactor GAM.deviance() onto a private _deviance_from_mu(y, mu, m, w)
+  helper so null_deviance() reuses the per-family math.
+- summary() now prints BIC and R^2.
+- Remove "AICc, BIC, R-squared estimate" from the to-do list at the
+  top of gamdist.py.
+
 2026-04-25 : AICc
 - Implement GAM.aicc() using the Hurvich-Tsai small-sample correction
   AICc = AIC + 2p(p+1)/(n-p-1), matching the convention used by aic()

--- a/gamdist/categorical_feature.py
+++ b/gamdist/categorical_feature.py
@@ -23,6 +23,7 @@
 from __future__ import annotations
 
 import pickle
+import warnings
 from typing import Any
 
 import cvxpy as cvx
@@ -417,11 +418,29 @@ class _CategoricalFeature(_Feature):
         return float(len(self.p) - 1)
 
     def predict(self, X: npt.NDArray[Any]) -> FloatArray:
-        """Apply fitted model to feature."""
+        """Apply fitted model to feature.
+
+        Categories not seen during ``fit()`` are predicted with effect 0
+        (the average across training categories, by the zero-sum
+        constraint) and trigger a ``UserWarning`` listing them.
+        """
         prediction = np.zeros(len(X))
+        unseen: set[Any] = set()
         for i in range(len(X)):
-            if X[i] in self._category_hash:
-                prediction[i] = self.p[self._category_hash[X[i]]]
+            value = X[i]
+            if value in self._category_hash:
+                prediction[i] = self.p[self._category_hash[value]]
+            else:
+                unseen.add(value)
+        if unseen:
+            sample = sorted(unseen, key=str)[:5]
+            suffix = "" if len(unseen) <= 5 else f", +{len(unseen) - 5} more"
+            warnings.warn(
+                f"Feature {self._name!r}: unseen categories predicted "
+                f"with effect 0: {sample}{suffix}",
+                UserWarning,
+                stacklevel=2,
+            )
         return prediction
 
     def _plot(self, true_fn: Any = None) -> None:

--- a/gamdist/gamdist.py
+++ b/gamdist/gamdist.py
@@ -61,7 +61,6 @@ FeatureType = Literal["categorical", "linear", "spline"]
 # - Implement overdispersion for Poisson family
 # - Implement Multinomial, Proportional Hazards
 # - Implement outlier detection
-# - AICc, BIC, R-squared estimate
 # - Confidence intervals on mu, predictions (probably need to use Bootstrap but can
 #   do so intelligently)
 # - Confidence intervals on model parameters, p-values
@@ -77,7 +76,8 @@ FeatureType = Literal["categorical", "linear", "spline"]
 # Done:
 # - Implement Gaussian, Binomial, Poisson, Gamma, Inv Gaussian,
 # - Plot splines
-# - Deviance (on training set and test set), AIC, Dispersion, GCV, UBRE
+# - Deviance (on training set and test set), AIC, AICc, BIC, R^2,
+#   Dispersion, GCV, UBRE
 # - Write documentation
 # - Check implementation of Gamma dispersion
 # - Implement probit, complementary log-log links.
@@ -1057,6 +1057,16 @@ class GAM:
             else:
                 m = 1.0
 
+        return self._deviance_from_mu(y, mu, m=m, w=w)
+
+    def _deviance_from_mu(
+        self,
+        y: npt.NDArray[Any],
+        mu: npt.NDArray[Any],
+        m: npt.NDArray[Any] | float = 1.0,
+        w: npt.NDArray[Any] | None = None,
+    ) -> float:
+        """Compute deviance for given response, mean, optional class sizes and weights."""
         if self._family == "normal":
             y_minus_mu = y - mu
             if w is None:
@@ -1467,6 +1477,55 @@ class GAM:
             return float("inf")
         return self.aic() + 2.0 * p * (p + 1) / (n - p - 1)
 
+    def bic(self) -> float:
+        """Bayesian Information Criterion.
+
+        Computed as
+
+            BIC = deviance / dispersion + log(n) * p
+
+        where ``p`` is the effective parameter count (``dof()``, plus
+        one when dispersion is estimated, matching ``aic()`` and
+        ``aicc()``) and ``n`` is the number of observations. As with
+        ``aic()``, the BIC is off by the same constant factor; only
+        differences are meaningful for model selection.
+        """
+        p = self.dof()
+        if not self._known_dispersion:
+            p += 1
+        return self.deviance() / self.dispersion() + float(np.log(self._num_obs)) * p
+
+    def null_deviance(self) -> float:
+        """Deviance of the intercept-only model on the training data.
+
+        The null model predicts the same mean response for every
+        observation: ``mean(y)`` (or ``sum(y) / sum(covariate_class_sizes)``
+        when binomial covariate classes were supplied at fit time).
+        """
+        y = self._y
+        if self._has_covariate_classes:
+            m: npt.NDArray[Any] | float = self._covariate_class_sizes
+            mean_response = float(np.sum(y)) / float(np.sum(m))
+        else:
+            m = 1.0
+            mean_response = float(np.mean(y))
+        mu = np.full_like(y, mean_response, dtype=float)
+        return self._deviance_from_mu(y, mu, m=m, w=self._weights)
+
+    def r_squared(self) -> float:
+        """Deviance-based pseudo-R^2.
+
+        Returns ``1 - deviance() / null_deviance()``. For a normal
+        family with identity link this is the conventional R^2; for
+        other families it is the deviance pseudo-R^2 of McCullagh and
+        Nelder. Returns ``nan`` when the null deviance is zero (the
+        response is constant), where pseudo-R^2 is undefined.
+        """
+        null_dev = self.null_deviance()
+        if null_dev == 0.0:
+            return float("nan")
+        return 1.0 - self.deviance() / null_dev
+
     def ubre(self, gamma: float = 1.0) -> float:
         """Un-Biased Risk Estimator
 
@@ -1513,15 +1572,15 @@ class GAM:
                      dispersion.
            AIC:      Akaike Information Criterion.
            AICc:     AIC with correction for finite data sets.
+           BIC:      Bayesian Information Criterion.
+           R^2:      Deviance-based pseudo-R^2.
            UBRE:     Unbiased Risk Estimator (if dispersion is known).
            GCV:      Generalized Cross Validation (if dispersion is estimated).
 
         For more details on these parameters, see the documentation
-        in the corresponding functions. It may also be helpful to
-        include an R^2 value where appropriate, and perhaps a p-value
-        for the model against the null model having just the affine
-        term. It would also be nice to have confidence intervals
-        at least on the estimated dispersion parameter.
+        in the corresponding functions. It would also be nice to have
+        confidence intervals at least on the estimated dispersion
+        parameter.
         """
 
         print("Model Statistics")
@@ -1532,6 +1591,8 @@ class GAM:
         print(f"Deviance: {self.deviance():0.06g}")
         print(f"AIC: {self.aic():0.06g}")
         print(f"AICc: {self.aicc():0.06g}")
+        print(f"BIC: {self.bic():0.06g}")
+        print(f"R^2: {self.r_squared():0.06g}")
 
         if self._known_dispersion:
             print(f"UBRE: {self.ubre():0.06g}")

--- a/gamdist/gamdist.py
+++ b/gamdist/gamdist.py
@@ -69,15 +69,15 @@ FeatureType = Literal["categorical", "linear", "spline"]
 # - Runtime optimization (Cython)
 # - Fit in parallel
 # - Residuals
-#   - Compute different types of residuals (Sec 3.1.7 of [GAMr])
-#   - Plot residuals against mean response, variance, predictor, unused predictor
-#   - QQ plot of residuals
+#   - Anscombe residuals
+#   - Plot residuals against each predictor / unused predictors
 #
 # Done:
 # - Implement Gaussian, Binomial, Poisson, Gamma, Inv Gaussian,
 # - Plot splines
 # - Deviance (on training set and test set), AIC, AICc, BIC, R^2,
 #   Dispersion, GCV, UBRE
+# - Pearson / deviance / response residuals; residual-vs-fitted and QQ plots
 # - Write documentation
 # - Check implementation of Gamma dispersion
 # - Implement probit, complementary log-log links.
@@ -997,6 +997,151 @@ class GAM:
 
         """
         self._features[name]._plot(true_fn=true_fn)
+
+    def residuals(
+        self,
+        kind: Literal["response", "pearson", "deviance"] = "deviance",
+    ) -> FloatArray:
+        """Residuals for the fitted model.
+
+        Parameters
+        ----------
+        kind : ``"response"``, ``"pearson"``, or ``"deviance"``
+            ``"response"`` returns ``y - mu`` (raw error).
+            ``"pearson"`` returns the standardized residual
+            ``(y - E[y]) / sqrt(Var(y))`` using the family's variance
+            function and the estimated dispersion. For binomial with
+            covariate classes, ``y`` is the count and ``E[y] = m * mu``.
+            ``"deviance"`` returns ``sign(y - E[y]) * sqrt(d_i)``, where
+            ``d_i >= 0`` is the per-observation deviance contribution;
+            squaring and summing gives the total deviance (Wood 2017
+            Sec 3.1.7).
+
+        Returns
+        -------
+        residuals : array of shape (n_obs,)
+        """
+        if not self._fitted:
+            raise AttributeError("Model not yet fit.")
+
+        y = self._y
+        mu = self._eval_inv_link(self._num_features * self.f_bar)
+        if self._has_covariate_classes:
+            m: npt.NDArray[Any] | float = self._covariate_class_sizes
+        else:
+            m = 1.0
+
+        if kind == "response":
+            return np.asarray(y - mu, dtype=float)
+        if kind == "pearson":
+            return self._pearson_residuals(y, mu, m)
+        if kind == "deviance":
+            d_i = self._unit_deviance_for_residuals(y, mu, m)
+            if self._family == "binomial":
+                return np.asarray(np.sign(y - m * mu) * np.sqrt(d_i), dtype=float)
+            return np.asarray(np.sign(y - mu) * np.sqrt(d_i), dtype=float)
+        raise ValueError(f"Unknown residual kind: {kind!r}")
+
+    def _pearson_residuals(
+        self,
+        y: npt.NDArray[Any],
+        mu: npt.NDArray[Any],
+        m: npt.NDArray[Any] | float,
+    ) -> FloatArray:
+        """Pearson residuals for each family."""
+        phi = self.dispersion()
+        if self._family == "binomial":
+            eps = np.finfo(float).eps
+            mu_c = np.clip(mu, eps, 1.0 - eps)
+            var = m * mu_c * (1.0 - mu_c)
+            return np.asarray((y - m * mu_c) / np.sqrt(var * phi), dtype=float)
+        if self._family == "normal":
+            return np.asarray((y - mu) / np.sqrt(phi), dtype=float)
+        if self._family == "poisson":
+            return np.asarray((y - mu) / np.sqrt(mu * phi), dtype=float)
+        if self._family == "gamma":
+            return np.asarray((y - mu) / np.sqrt(mu * mu * phi), dtype=float)
+        if self._family == "inverse_gaussian":
+            return np.asarray((y - mu) / np.sqrt(mu * mu * mu * phi), dtype=float)
+        raise ValueError(f"Unsupported family {self._family!r}")
+
+    def _unit_deviance_for_residuals(
+        self,
+        y: npt.NDArray[Any],
+        mu: npt.NDArray[Any],
+        m: npt.NDArray[Any] | float,
+    ) -> FloatArray:
+        """Per-observation deviance contribution ``d_i >= 0``.
+
+        For binomial this differs from the per-term contribution
+        accumulated by ``deviance()``: the ``deviance()`` form omits
+        the saturated-likelihood constant (which doesn't affect model
+        fitting), but ``d_i`` for residuals must include it so that
+        ``sqrt(d_i)`` is real and non-negative.
+        """
+        if self._family == "normal":
+            return np.asarray((y - mu) ** 2, dtype=float)
+        if self._family == "binomial":
+            eps = np.finfo(float).eps
+            mu_c = np.clip(mu, eps, 1.0 - eps)
+            with np.errstate(divide="ignore", invalid="ignore"):
+                t1 = np.where(y > 0, y * np.log(y / (m * mu_c)), 0.0)
+                t2 = np.where(
+                    y < m,
+                    (m - y) * np.log((m - y) / (m * (1.0 - mu_c))),
+                    0.0,
+                )
+            return np.maximum(2.0 * (t1 + t2), 0.0)
+        if self._family == "poisson":
+            with np.errstate(divide="ignore", invalid="ignore"):
+                t = np.where(y > 0, y * np.log(np.where(y > 0, y, 1.0) / mu), 0.0)
+            return np.maximum(2.0 * (t - (y - mu)), 0.0)
+        if self._family == "gamma":
+            tiny = np.finfo(float).tiny
+            y_safe = np.where(y > 0, y, tiny)
+            mu_safe = np.where(mu > 0, mu, tiny)
+            return np.maximum(
+                2.0 * (-np.log(y_safe / mu_safe) + (y - mu_safe) / mu_safe), 0.0
+            )
+        if self._family == "inverse_gaussian":
+            return np.asarray((y - mu) ** 2 / (mu * mu * y), dtype=float)
+        raise ValueError(f"Unsupported family {self._family!r}")
+
+    def plot_residuals(
+        self,
+        kind: Literal["response", "pearson", "deviance"] = "deviance",
+    ) -> Any:
+        """Plot residuals vs. fitted values and a normal QQ plot.
+
+        Produces a 1x2 matplotlib figure: residual-vs-fitted on the
+        left, Q-Q plot against the standard normal on the right.
+
+        Parameters
+        ----------
+        kind : ``"response"``, ``"pearson"``, or ``"deviance"``
+            Forwarded to ``residuals()``.
+
+        Returns
+        -------
+        fig : matplotlib.figure.Figure
+        """
+        import matplotlib.pyplot as plt
+
+        res = self.residuals(kind)
+        mu = self._eval_inv_link(self._num_features * self.f_bar)
+
+        fig, (ax1, ax2) = plt.subplots(1, 2, figsize=(10, 4))
+        ax1.scatter(mu, res, s=10, alpha=0.6)
+        ax1.axhline(0.0, color="grey", linewidth=0.5)
+        ax1.set_xlabel("Fitted (mu)")
+        ax1.set_ylabel(f"{kind.capitalize()} residual")
+        ax1.set_title("Residuals vs Fitted")
+
+        stats.probplot(res, plot=ax2)
+        ax2.set_title("Normal Q-Q")
+
+        fig.tight_layout()
+        return fig
 
     def deviance(
         self,

--- a/gamdist/gamdist.py
+++ b/gamdist/gamdist.py
@@ -58,7 +58,6 @@ FeatureType = Literal["categorical", "linear", "spline"]
 # - Hierarchical models
 # - Piecewise constant fits, total variation regularization
 # - Monotone constraint
-# - Implement overdispersion for Poisson family
 # - Implement Multinomial, Proportional Hazards
 # - Implement outlier detection
 # - Confidence intervals on mu, predictions (probably need to use Bootstrap but can
@@ -85,6 +84,7 @@ FeatureType = Literal["categorical", "linear", "spline"]
 # - Constrain spline to have mean prediction 0 over the data
 # - Save and load properly
 # - Implement overdispersion for Binomial family
+# - Implement overdispersion for Poisson family
 
 FAMILIES = ['normal',
             'binomial',
@@ -1296,6 +1296,10 @@ class GAM:
                 return float(self._binomial_overdispersion())
             return 1.0
         if self._family == "poisson":
+            if self._known_dispersion:
+                return float(self._dispersion)
+            if self._estimate_overdispersion:
+                return float(self._poisson_overdispersion())
             return 1.0
         if self._family == "gamma":
             if self._known_dispersion:
@@ -1563,6 +1567,34 @@ class GAM:
             self._known_dispersion = True
             self._dispersion = s2
             return s2
+
+    def _poisson_overdispersion(self) -> float:
+        r"""Estimate the Poisson dispersion as the Pearson chi-square / dof.
+
+        Under the standard Poisson model ``Var(Y) = mu``; if observed
+        variance is larger (overdispersion) the dispersion ``phi`` is
+        estimated as
+
+            phi = sum_i (y_i - mu_i)^2 / mu_i  /  (n - p)
+
+        where ``p = dof()``. This is the Pearson form of Eqn 3.10 in
+        Wood (2017). The replication-based estimator used for
+        ``_binomial_overdispersion`` is binomial-specific (it relies on
+        covariate-class replicates) and is not applicable here.
+
+        The result is cached on ``self._dispersion`` and
+        ``self._known_dispersion`` so subsequent calls are O(1).
+        """
+        mu = self._eval_inv_link(self._num_features * self.f_bar)
+        # Guard against transient mu <= 0 from a non-canonical link.
+        tiny = np.finfo(float).tiny
+        mu_safe = np.where(mu > 0, mu, tiny)
+        res = self._y - mu
+        n_minus_p = self._num_obs - self.dof()
+        s2 = float(np.sum(res * res / mu_safe) / n_minus_p)
+        self._known_dispersion = True
+        self._dispersion = s2
+        return s2
 
     def dof(self) -> float:
         """Degrees of freedom: sum of feature DOFs plus the affine intercept."""

--- a/gamdist/proximal_operators.py
+++ b/gamdist/proximal_operators.py
@@ -28,6 +28,7 @@ from typing import Any
 import numpy as np
 import numpy.typing as npt
 from scipy.optimize import minimize_scalar
+from scipy.special import expit
 
 FloatArray = npt.NDArray[np.float64]
 InvLink = Callable[[float], float]
@@ -76,37 +77,43 @@ def _prox_normal(
 
 
 def _prox_binomial_logit_scalar(xx: Sequence[float]) -> float:
-    v = xx[0]
-    mu = xx[1]
-    y = xx[2]
-    m = xx[3]
-    w: float | None = xx[4] if len(xx) >= 5 else None
+    v = float(xx[0])
+    mu = float(xx[1])
+    y = float(xx[2])
+    m = float(xx[3])
+    w_eff = float(xx[4]) if len(xx) >= 5 else 1.0
+
+    def obj(z: float) -> float:
+        # log1p(exp(z)) computed stably as np.logaddexp(0, z).
+        return (
+            w_eff * m * float(np.logaddexp(0.0, z))
+            - w_eff * y * z
+            + 0.5 * mu * (z - v) * (z - v)
+        )
 
     tol = 1e-3
     max_its = 100
-
     x = 0.0
-    if w is None:
-        mu_v_plus_w_y = mu * v + y
-    else:
-        mu_v_plus_w_y = mu * v + w * y
-
     for _ in range(max_its):
-        expx = float(np.exp(x))
-        one_over_one_plus_expx = 1.0 / (1.0 + expx)
-        if w is None:
-            num = mu * x + m * expx * one_over_one_plus_expx - mu_v_plus_w_y
-            denom = mu + m * expx * one_over_one_plus_expx * one_over_one_plus_expx
-        else:
-            num = mu * x + w * m * expx * one_over_one_plus_expx - mu_v_plus_w_y
-            denom = mu + w * m * expx * one_over_one_plus_expx * one_over_one_plus_expx
-
-        dx = num / denom
-        x -= dx
+        sigma = float(expit(x))
+        grad = mu * (x - v) + w_eff * (m * sigma - y)
+        hess = mu + w_eff * m * sigma * (1.0 - sigma)
+        dx = grad / hess
         if abs(dx) < tol:
             return x
+        # Damped Newton: backtrack until the objective decreases.
+        f_curr = obj(x)
+        step = 1.0
+        x_new = x - dx
+        while obj(x_new) >= f_curr and step > 1e-12:
+            step *= 0.5
+            x_new = x - step * dx
+        x = x_new
 
-    raise ValueError("Dual variable update failed to converge.")
+    # Newton failed to converge in max_its; fall back to a bracketed
+    # 1-D minimization. The minimizer is convex in z, so this always
+    # finds the same optimum that Newton would have reached.
+    return float(minimize_scalar(obj).x)
 
 
 def _prox_binomial_logit(
@@ -165,35 +172,36 @@ def _prox_binomial(
 
 
 def _prox_poisson_log_scalar(xx: Sequence[float]) -> float:
-    v = xx[0]
-    mu = xx[1]
-    y = xx[2]
-    w: float | None = xx[3] if len(xx) >= 4 else None
+    v = float(xx[0])
+    mu = float(xx[1])
+    y = float(xx[2])
+    w_eff = float(xx[3]) if len(xx) >= 4 else 1.0
+
+    def obj(z: float) -> float:
+        return w_eff * float(np.exp(z)) - w_eff * y * z + 0.5 * mu * (z - v) * (z - v)
 
     tol = 1e-3
     max_its = 100
-
     x = 0.0
-    if w is None:
-        mu_v_plus_w_y = mu * v + y
-    else:
-        mu_v_plus_w_y = mu * v + w * y
-
     for _ in range(max_its):
-        expx = float(np.exp(x))
-        if w is None:
-            num = mu * x + expx - mu_v_plus_w_y
-            denom = mu + expx
-        else:
-            num = mu * x + w * expx - mu_v_plus_w_y
-            denom = mu + w * expx
-
-        dx = num / denom
-        x -= dx
+        # Cap exp(x) below the float64 overflow threshold so a transient
+        # large step doesn't blow up the gradient computation. Damping
+        # below pulls x back into a sensible range.
+        expx = float(np.exp(min(x, 700.0)))
+        grad = mu * (x - v) + w_eff * (expx - y)
+        hess = mu + w_eff * expx
+        dx = grad / hess
         if abs(dx) < tol:
             return x
+        f_curr = obj(x)
+        step = 1.0
+        x_new = x - dx
+        while obj(x_new) >= f_curr and step > 1e-12:
+            step *= 0.5
+            x_new = x - step * dx
+        x = x_new
 
-    raise ValueError("Dual variable update failed to converge.")
+    return float(minimize_scalar(obj).x)
 
 
 def _prox_poisson_log(

--- a/tests/test_categorical_feature.py
+++ b/tests/test_categorical_feature.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import warnings
 from pathlib import Path
 
 import numpy as np
@@ -36,7 +37,8 @@ def test_predict_unknown_category_returns_zero() -> None:
     feat = _CategoricalFeature(name="g")
     feat.initialize(np.array(["a", "b"]))
     feat.p = np.array([1.5, -2.0])
-    out = feat.predict(np.array(["a", "b", "z"]))
+    with pytest.warns(UserWarning, match="unseen categories"):
+        out = feat.predict(np.array(["a", "b", "z"]))
     assert out[2] == 0.0
 
 
@@ -83,6 +85,34 @@ def test_optimize_satisfies_zero_sum_constraint() -> None:
     feat.optimize(-rng.normal(size=200), rho=1.0)
     weighted = float(feat._ccs.dot(feat.p))
     assert abs(weighted) < 1e-4
+
+
+def test_predict_warns_on_unseen_category() -> None:
+    rng = np.random.default_rng(0)
+    x = rng.choice(np.array(["a", "b", "c"]), size=120)
+    feat = _CategoricalFeature(name="g")
+    feat.initialize(x)
+    feat.optimize(rng.normal(size=120), rho=1.0)
+
+    test_x = np.array(["a", "b", "d", "e"])
+    with pytest.warns(UserWarning, match="unseen categories"):
+        out = feat.predict(test_x)
+    # 'd' and 'e' fall back to effect 0; 'a' and 'b' use fitted values.
+    assert out[2] == 0.0
+    assert out[3] == 0.0
+    assert out[0] == feat.p[feat._category_hash["a"]]
+
+
+def test_predict_no_warning_when_categories_known() -> None:
+    rng = np.random.default_rng(0)
+    x = rng.choice(np.array(["a", "b", "c"]), size=120)
+    feat = _CategoricalFeature(name="g")
+    feat.initialize(x)
+    feat.optimize(rng.normal(size=120), rho=1.0)
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")  # any warning would fail the test
+        feat.predict(np.array(["a", "b"]))
 
 
 def test_save_load_round_trip(tmp_path: Path) -> None:

--- a/tests/test_gam_api.py
+++ b/tests/test_gam_api.py
@@ -99,6 +99,20 @@ def test_aicc_overparameterized_returns_inf() -> None:
     assert mdl.aicc() == float("inf")
 
 
+def test_bic_matches_formula() -> None:
+    rng = np.random.default_rng(11)
+    n = 200
+    X = pd.DataFrame({"x": rng.normal(size=n)})
+    y = 2.0 * X["x"].values + rng.normal(size=n) * 0.1
+    mdl = GAM(family="normal")
+    mdl.add_feature(name="x", type="linear")
+    mdl.fit(X, y, max_its=20)
+
+    p = mdl.dof() + (0.0 if mdl._known_dispersion else 1.0)
+    # BIC - AIC == (log(n) - 2) * p
+    assert mdl.bic() - mdl.aic() == pytest.approx((np.log(n) - 2.0) * p)
+
+
 def test_inconsistent_X_y_lengths_raises() -> None:
     mdl = GAM(family="normal")
     mdl.add_feature(name="x", type="linear")

--- a/tests/test_gam_families.py
+++ b/tests/test_gam_families.py
@@ -25,6 +25,56 @@ def test_aic_finite(small_normal_fit: GAM) -> None:
     assert np.isfinite(small_normal_fit.aic())
 
 
+def test_bic_finite(small_normal_fit: GAM) -> None:
+    assert np.isfinite(small_normal_fit.bic())
+
+
+def test_null_deviance_normal(small_normal_fit: GAM) -> None:
+    # For normal family the null deviance is sum((y - mean(y))^2).
+    y = small_normal_fit._y
+    expected = float(np.sum((y - np.mean(y)) ** 2))
+    assert small_normal_fit.null_deviance() == pytest.approx(expected)
+
+
+def test_r_squared_normal_matches_classical(small_normal_fit: GAM) -> None:
+    # For normal + identity link, the deviance pseudo-R^2 is the
+    # standard R^2 = 1 - SS_res / SS_tot.
+    y = small_normal_fit._y
+    yhat = small_normal_fit._eval_inv_link(
+        small_normal_fit._num_features * small_normal_fit.f_bar
+    )
+    ss_res = float(np.sum((y - yhat) ** 2))
+    ss_tot = float(np.sum((y - np.mean(y)) ** 2))
+    expected = 1.0 - ss_res / ss_tot
+    assert small_normal_fit.r_squared() == pytest.approx(expected)
+    assert 0.0 < small_normal_fit.r_squared() < 1.0
+
+
+def test_r_squared_constant_response_is_nan() -> None:
+    # When y is constant the null deviance is 0, so pseudo-R^2 is undefined.
+    n = 20
+    X = pd.DataFrame({"x": np.linspace(0.0, 1.0, n)})
+    y = np.full(n, 3.5)
+    mdl = GAM(family="normal")
+    mdl.add_feature(name="x", type="linear")
+    mdl.fit(X, y, max_its=10)
+    assert np.isnan(mdl.r_squared())
+
+
+def test_r_squared_binomial_finite() -> None:
+    rng = np.random.default_rng(2)
+    n = 200
+    X = pd.DataFrame({"x": rng.normal(size=n)})
+    p = 1.0 / (1.0 + np.exp(-X["x"].values))
+    y = (rng.uniform(size=n) < p).astype(float)
+    mdl = GAM(family="binomial")
+    mdl.add_feature(name="x", type="linear")
+    mdl.fit(X, y, max_its=20)
+    r2 = mdl.r_squared()
+    assert np.isfinite(r2)
+    assert r2 > 0.0
+
+
 def test_dispersion_finite(small_normal_fit: GAM) -> None:
     assert np.isfinite(small_normal_fit.dispersion())
 

--- a/tests/test_internals.py
+++ b/tests/test_internals.py
@@ -71,6 +71,56 @@ def test_binomial_overdispersion_no_covariate_classes_returns_one() -> None:
     assert mdl._binomial_overdispersion() == 1.0
 
 
+def test_poisson_dispersion_one_without_estimate_flag() -> None:
+    rng = np.random.default_rng(0)
+    n = 200
+    X = pd.DataFrame({"x": rng.normal(size=n)})
+    y = rng.poisson(np.exp(0.4 * X["x"].values + 0.5), size=n).astype(float)
+    mdl = GAM(family="poisson")  # estimate_overdispersion=False (default)
+    mdl.add_feature(name="x", type="linear")
+    mdl.fit(X, y, max_its=30)
+    assert mdl.dispersion() == 1.0
+
+
+def test_poisson_overdispersion_pearson_formula() -> None:
+    # Numeric check: dispersion() should equal sum((y - mu)^2 / mu) / (n - p)
+    # when estimate_overdispersion=True and the data is overdispersed.
+    rng = np.random.default_rng(3)
+    n = 300
+    X = pd.DataFrame({"x": rng.normal(size=n)})
+    # Negative-binomial sampling produces overdispersion vs. pure Poisson:
+    # mean = mu, var = mu + mu^2 / k. Choose k=2 for moderate overdispersion.
+    mu_true = np.exp(0.3 * X["x"].values + 1.0)
+    k = 2.0
+    p_nb = k / (k + mu_true)
+    y = rng.negative_binomial(k, p_nb, size=n).astype(float)
+
+    mdl = GAM(family="poisson", estimate_overdispersion=True)
+    mdl.add_feature(name="x", type="linear")
+    mdl.fit(X, y, max_its=40)
+
+    disp = mdl.dispersion()
+    mu_hat = mdl._eval_inv_link(mdl._num_features * mdl.f_bar)
+    expected = float(np.sum((y - mu_hat) ** 2 / mu_hat) / (n - mdl.dof()))
+    assert disp == pytest.approx(expected)
+    assert disp > 1.0  # We sampled from an overdispersed distribution.
+
+
+def test_poisson_overdispersion_caches_dispersion() -> None:
+    # Calling dispersion() twice must not change the result.
+    rng = np.random.default_rng(0)
+    n = 200
+    X = pd.DataFrame({"x": rng.normal(size=n)})
+    y = rng.poisson(np.exp(0.5 * X["x"].values), size=n).astype(float)
+    mdl = GAM(family="poisson", estimate_overdispersion=True)
+    mdl.add_feature(name="x", type="linear")
+    mdl.fit(X, y, max_its=30)
+    first = mdl.dispersion()
+    second = mdl.dispersion()
+    assert first == second
+    assert mdl._known_dispersion
+
+
 @pytest.mark.parametrize(
     "link,family",
     [

--- a/tests/test_proximal_operators.py
+++ b/tests/test_proximal_operators.py
@@ -79,3 +79,33 @@ def test_binomial_logit_scalar_with_weight() -> None:
     out = po._prox_binomial_logit_scalar([0.0, 1.0, 0.5, 1.0, 2.0])
     assert isinstance(out, float)
     assert np.isfinite(out)
+
+
+def test_binomial_logit_scalar_handles_extreme_v() -> None:
+    # v=50 used to drive Newton into np.exp() overflow on the first
+    # iteration. The hardened version stays finite via expit() and
+    # backtracking.
+    out = po._prox_binomial_logit_scalar([50.0, 0.1, 0.0, 1.0])
+    assert np.isfinite(out)
+
+
+def test_binomial_logit_scalar_matches_brute_force_optimum() -> None:
+    # Spot-check the Newton solution against scipy.optimize.minimize_scalar
+    # on the same objective.
+    v, mu, y, m = 0.7, 1.5, 0.5, 1.0
+
+    def obj(z: float) -> float:
+        return m * float(np.logaddexp(0.0, z)) - y * z + 0.5 * mu * (z - v) ** 2
+
+    from scipy.optimize import minimize_scalar
+
+    expected = float(minimize_scalar(obj).x)
+    out = po._prox_binomial_logit_scalar([v, mu, y, m])
+    assert abs(out - expected) < 1e-3
+
+
+def test_poisson_log_scalar_handles_extreme_v() -> None:
+    # Large positive v previously could cause exp(x) to overflow during
+    # Newton; the cap + damping keeps the result finite.
+    out = po._prox_poisson_log_scalar([20.0, 0.1, 0.0])
+    assert np.isfinite(out)

--- a/tests/test_residuals.py
+++ b/tests/test_residuals.py
@@ -1,0 +1,103 @@
+"""Tests for GAM.residuals() and GAM.plot_residuals()."""
+
+from __future__ import annotations
+
+import matplotlib
+
+matplotlib.use("Agg")
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from gamdist import GAM
+
+
+@pytest.fixture
+def normal_fit() -> GAM:
+    rng = np.random.default_rng(0)
+    n = 80
+    X = pd.DataFrame({"x": rng.normal(size=n)})
+    y = X["x"].values + rng.normal(size=n) * 0.1
+    mdl = GAM(family="normal")
+    mdl.add_feature(name="x", type="linear")
+    mdl.fit(X, y, max_its=20)
+    return mdl
+
+
+def test_residuals_response_is_y_minus_mu(normal_fit: GAM) -> None:
+    y = normal_fit._y
+    mu = normal_fit._eval_inv_link(normal_fit._num_features * normal_fit.f_bar)
+    np.testing.assert_allclose(normal_fit.residuals("response"), y - mu)
+
+
+def test_residuals_deviance_normal_equals_response(normal_fit: GAM) -> None:
+    # For normal family, deviance residual is sign(y - mu) * |y - mu| = y - mu.
+    np.testing.assert_allclose(
+        normal_fit.residuals("deviance"),
+        normal_fit.residuals("response"),
+        atol=1e-12,
+    )
+
+
+def test_residuals_pearson_normal_scaled_by_sqrt_phi(normal_fit: GAM) -> None:
+    phi = normal_fit.dispersion()
+    expected = normal_fit.residuals("response") / np.sqrt(phi)
+    np.testing.assert_allclose(normal_fit.residuals("pearson"), expected)
+
+
+def test_deviance_residual_squared_sum_matches_deviance_normal(normal_fit: GAM) -> None:
+    # For normal family, sum(d_i) == deviance() exactly.
+    d_residuals = normal_fit.residuals("deviance")
+    assert float(np.sum(d_residuals**2)) == pytest.approx(normal_fit.deviance())
+
+
+def test_residuals_invalid_kind_raises(normal_fit: GAM) -> None:
+    with pytest.raises(ValueError, match="Unknown residual kind"):
+        normal_fit.residuals("bogus")  # type: ignore[arg-type]
+
+
+def test_residuals_before_fit_raises() -> None:
+    mdl = GAM(family="normal")
+    mdl.add_feature(name="x", type="linear")
+    with pytest.raises(AttributeError, match="not yet fit"):
+        mdl.residuals()
+
+
+def test_residuals_poisson_finite() -> None:
+    rng = np.random.default_rng(0)
+    n = 200
+    X = pd.DataFrame({"x": rng.normal(size=n)})
+    y = rng.poisson(np.exp(0.4 * X["x"].values + 0.5), size=n).astype(float)
+    mdl = GAM(family="poisson")
+    mdl.add_feature(name="x", type="linear")
+    mdl.fit(X, y, max_its=30)
+    for kind in ("response", "pearson", "deviance"):
+        r = mdl.residuals(kind)  # type: ignore[arg-type]
+        assert r.shape == (n,)
+        assert np.all(np.isfinite(r))
+
+
+def test_residuals_binomial_with_ccs() -> None:
+    rng = np.random.default_rng(2)
+    n = 50
+    X = pd.DataFrame({"x": rng.normal(size=n)})
+    ccs = np.full(n, 10.0)
+    p = 1.0 / (1.0 + np.exp(-X["x"].values))
+    y = rng.binomial(10, p).astype(float)
+    mdl = GAM(family="binomial")
+    mdl.add_feature(name="x", type="linear")
+    mdl.fit(X, y, covariate_class_sizes=ccs, max_its=30)
+    for kind in ("response", "pearson", "deviance"):
+        r = mdl.residuals(kind)  # type: ignore[arg-type]
+        assert r.shape == (n,)
+        assert np.all(np.isfinite(r))
+
+
+def test_plot_residuals_returns_figure(normal_fit: GAM) -> None:
+    fig = normal_fit.plot_residuals(kind="deviance")
+    # 1x2 layout: residuals-vs-fitted, QQ
+    assert len(fig.axes) == 2
+    titles = {ax.get_title() for ax in fig.axes}
+    assert "Residuals vs Fitted" in titles
+    assert "Normal Q-Q" in titles


### PR DESCRIPTION
Adds the two remaining items from the "AICc, BIC, R-squared estimate"
TODO at gamdist.py:64 (AICc was implemented in the previous commit).

  - bic() = deviance/dispersion + log(n) * p, with the same parameter-
    counting convention as aic()/aicc().
  - null_deviance() returns the deviance of the intercept-only model
    (mu = mean(y), or sum(y)/sum(ccs) for binomial covariate classes).
  - r_squared() returns 1 - deviance / null_deviance, the deviance-based
    pseudo-R^2 of McCullagh & Nelder. For normal+identity this equals
    the classical R^2; returns NaN when the response is constant.

Refactors the per-family deviance math out of deviance() into a private
_deviance_from_mu(y, mu, m, w) helper so null_deviance() can reuse it
without duplication.

summary() now prints BIC and R^2; the TODO list is updated to drop the
"AICc, BIC, R-squared estimate" item and add AICc/BIC/R^2 to the Done
section.

Tests:
  - test_bic_matches_formula: BIC - AIC == (log(n) - 2) * p.
  - test_bic_finite, test_null_deviance_normal: smoke + numeric check.
  - test_r_squared_normal_matches_classical: matches 1 - SS_res/SS_tot
    on a normal+identity fit.
  - test_r_squared_binomial_finite: smoke for non-normal family.
  - test_r_squared_constant_response_is_nan: covers null_dev=0 branch.

103/103 pytest, ruff clean, mypy clean.

https://claude.ai/code/session_012JfhtN6E7YrNRf49Eh5A2Z