### PR TITLE
feat: add Anscombe residuals (kind="anscombe") to GAM.residuals()

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,16 @@
+2026-04-25 : Anscombe residuals
+- Add kind="anscombe" to GAM.residuals() (and GAM.plot_residuals()).
+  Implements the family-specific variance-stabilizing transformation
+  A(t) = integral V(s)^(-1/3) ds (McCullagh & Nelder 1989 Sec 2.4.1):
+    * normal:           (y - mu) / sqrt(phi)  (== Pearson)
+    * binomial(m):      sqrt(m) * (A(y/m) - A(mu)) / [mu(1-mu)]^(1/6)
+                        / sqrt(phi), with A from the regularized
+                        incomplete beta with parameters (2/3, 2/3)
+    * poisson:          (3/2) * (y^(2/3) - mu^(2/3))
+                        / mu^(1/6) / sqrt(phi)
+    * gamma:            3 * (y^(1/3) - mu^(1/3)) / mu^(1/3) / sqrt(phi)
+    * inverse_gaussian: (log y - log mu) / sqrt(mu * phi)
+
 2026-04-25 : Cleanup follow-ups
 - Categorical predict() now emits a UserWarning naming any categories
   not seen during fit (effect 0 fallback is unchanged).

--- a/gamdist/gamdist.py
+++ b/gamdist/gamdist.py
@@ -68,7 +68,6 @@ FeatureType = Literal["categorical", "linear", "spline"]
 # - Runtime optimization (Cython)
 # - Fit in parallel
 # - Residuals
-#   - Anscombe residuals
 #   - Plot residuals against each predictor / unused predictors
 #
 # Done:
@@ -76,7 +75,8 @@ FeatureType = Literal["categorical", "linear", "spline"]
 # - Plot splines
 # - Deviance (on training set and test set), AIC, AICc, BIC, R^2,
 #   Dispersion, GCV, UBRE
-# - Pearson / deviance / response residuals; residual-vs-fitted and QQ plots
+# - Response, Pearson, deviance, Anscombe residuals;
+#   residual-vs-fitted and QQ plots
 # - Write documentation
 # - Check implementation of Gamma dispersion
 # - Implement probit, complementary log-log links.
@@ -1000,13 +1000,13 @@ class GAM:
 
     def residuals(
         self,
-        kind: Literal["response", "pearson", "deviance"] = "deviance",
+        kind: Literal["response", "pearson", "deviance", "anscombe"] = "deviance",
     ) -> FloatArray:
         """Residuals for the fitted model.
 
         Parameters
         ----------
-        kind : ``"response"``, ``"pearson"``, or ``"deviance"``
+        kind : ``"response"``, ``"pearson"``, ``"deviance"``, or ``"anscombe"``
             ``"response"`` returns ``y - mu`` (raw error).
             ``"pearson"`` returns the standardized residual
             ``(y - E[y]) / sqrt(Var(y))`` using the family's variance
@@ -1016,6 +1016,12 @@ class GAM:
             ``d_i >= 0`` is the per-observation deviance contribution;
             squaring and summing gives the total deviance (Wood 2017
             Sec 3.1.7).
+            ``"anscombe"`` returns the family-specific transformation
+            ``(A(y) - A(mu)) / (V(mu)^(1/6) * sqrt(phi))`` with
+            ``A(t) = integral V(s)^(-1/3) ds``, chosen so the residual
+            is approximately standard-normal under correct
+            specification (McCullagh & Nelder 1989 Sec 2.4.1; Wood
+            2017 Sec 3.1.7).
 
         Returns
         -------
@@ -1040,6 +1046,8 @@ class GAM:
             if self._family == "binomial":
                 return np.asarray(np.sign(y - m * mu) * np.sqrt(d_i), dtype=float)
             return np.asarray(np.sign(y - mu) * np.sqrt(d_i), dtype=float)
+        if kind == "anscombe":
+            return self._anscombe_residuals(y, mu, m)
         raise ValueError(f"Unknown residual kind: {kind!r}")
 
     def _pearson_residuals(
@@ -1107,9 +1115,63 @@ class GAM:
             return np.asarray((y - mu) ** 2 / (mu * mu * y), dtype=float)
         raise ValueError(f"Unsupported family {self._family!r}")
 
+    def _anscombe_residuals(
+        self,
+        y: npt.NDArray[Any],
+        mu: npt.NDArray[Any],
+        m: npt.NDArray[Any] | float,
+    ) -> FloatArray:
+        r"""Anscombe residuals using the family-specific variance-stabilizing
+        transformation ``A(t) = \int V(s)^{-1/3} ds``.
+
+        The residual is
+
+            r_A = (A(y) - A(mu)) / (V(mu)^(1/6) * sqrt(phi))
+
+        with the binomial form scaled by ``sqrt(m)`` because the
+        per-trial proportion ``y/m`` has variance ``V(mu)/m``. See
+        McCullagh & Nelder (1989) Sec 2.4.1 / Table 2.5.
+        """
+        phi = self.dispersion()
+        if self._family == "normal":
+            # V(mu) = 1, A(t) = t -- coincides with the Pearson residual.
+            return np.asarray((y - mu) / np.sqrt(phi), dtype=float)
+        if self._family == "binomial":
+            eps = np.finfo(float).eps
+            mu_c = np.clip(mu, eps, 1.0 - eps)
+            prop = np.clip(y / m, eps, 1.0 - eps)
+            # A(p) = B(2/3, 2/3) * I(2/3, 2/3, p) where I is the regularized
+            # incomplete beta function.
+            scale = float(special.beta(2.0 / 3.0, 2.0 / 3.0))
+            a_y = scale * special.betainc(2.0 / 3.0, 2.0 / 3.0, prop)
+            a_mu = scale * special.betainc(2.0 / 3.0, 2.0 / 3.0, mu_c)
+            denom = (mu_c * (1.0 - mu_c)) ** (1.0 / 6.0) * np.sqrt(phi)
+            return np.asarray(np.sqrt(m) * (a_y - a_mu) / denom, dtype=float)
+        if self._family == "poisson":
+            # V(mu) = mu, A(t) = (3/2) t^(2/3).
+            return np.asarray(
+                1.5 * (y ** (2.0 / 3.0) - mu ** (2.0 / 3.0))
+                / mu ** (1.0 / 6.0) / np.sqrt(phi),
+                dtype=float,
+            )
+        if self._family == "gamma":
+            # V(mu) = mu^2, A(t) = 3 t^(1/3); V(mu)^(1/6) = mu^(1/3).
+            tiny = np.finfo(float).tiny
+            y_safe = np.where(y > 0, y, tiny)
+            mu_safe = np.where(mu > 0, mu, tiny)
+            return np.asarray(
+                3.0 * (y_safe ** (1.0 / 3.0) - mu_safe ** (1.0 / 3.0))
+                / mu_safe ** (1.0 / 3.0) / np.sqrt(phi),
+                dtype=float,
+            )
+        if self._family == "inverse_gaussian":
+            # V(mu) = mu^3, A(t) = log(t); V(mu)^(1/6) = sqrt(mu).
+            return np.asarray((np.log(y) - np.log(mu)) / np.sqrt(mu * phi), dtype=float)
+        raise ValueError(f"Unsupported family {self._family!r}")
+
     def plot_residuals(
         self,
-        kind: Literal["response", "pearson", "deviance"] = "deviance",
+        kind: Literal["response", "pearson", "deviance", "anscombe"] = "deviance",
     ) -> Any:
         """Plot residuals vs. fitted values and a normal QQ plot.
 

--- a/tests/test_residuals.py
+++ b/tests/test_residuals.py
@@ -101,3 +101,79 @@ def test_plot_residuals_returns_figure(normal_fit: GAM) -> None:
     titles = {ax.get_title() for ax in fig.axes}
     assert "Residuals vs Fitted" in titles
     assert "Normal Q-Q" in titles
+
+
+def test_anscombe_normal_equals_pearson(normal_fit: GAM) -> None:
+    # For normal family V(mu)=1 and A(t)=t, so Anscombe collapses to
+    # the Pearson residual.
+    np.testing.assert_allclose(
+        normal_fit.residuals("anscombe"),
+        normal_fit.residuals("pearson"),
+        atol=1e-12,
+    )
+
+
+def test_anscombe_poisson_matches_formula() -> None:
+    rng = np.random.default_rng(7)
+    n = 200
+    X = pd.DataFrame({"x": rng.normal(size=n)})
+    y = rng.poisson(np.exp(0.4 * X["x"].values + 0.5), size=n).astype(float)
+    mdl = GAM(family="poisson")
+    mdl.add_feature(name="x", type="linear")
+    mdl.fit(X, y, max_its=30)
+
+    mu = mdl._eval_inv_link(mdl._num_features * mdl.f_bar)
+    expected = 1.5 * (y ** (2 / 3) - mu ** (2 / 3)) / mu ** (1 / 6) / np.sqrt(
+        mdl.dispersion()
+    )
+    np.testing.assert_allclose(mdl.residuals("anscombe"), expected, rtol=1e-10)
+
+
+def test_anscombe_gamma_matches_formula() -> None:
+    # Use known dispersion to skip the (numerically finicky)
+    # _gamma_dispersion Newton estimator for the test.
+    rng = np.random.default_rng(0)
+    n = 100
+    X = pd.DataFrame({"x": rng.uniform(0.1, 0.5, size=n)})
+    y = rng.gamma(shape=4.0, scale=0.5, size=n)
+    mdl = GAM(family="gamma", dispersion=1.0)
+    mdl.add_feature(name="x", type="linear")
+    mdl.fit(X, y, max_its=30)
+
+    mu = mdl._eval_inv_link(mdl._num_features * mdl.f_bar)
+    expected = 3.0 * (y ** (1 / 3) - mu ** (1 / 3)) / mu ** (1 / 3)
+    np.testing.assert_allclose(mdl.residuals("anscombe"), expected, rtol=1e-10)
+
+
+def test_anscombe_binomial_with_ccs_finite() -> None:
+    rng = np.random.default_rng(2)
+    n = 50
+    X = pd.DataFrame({"x": rng.normal(size=n)})
+    ccs = np.full(n, 10.0)
+    p = 1.0 / (1.0 + np.exp(-X["x"].values))
+    y = rng.binomial(10, p).astype(float)
+    mdl = GAM(family="binomial")
+    mdl.add_feature(name="x", type="linear")
+    mdl.fit(X, y, covariate_class_sizes=ccs, max_its=30)
+    r = mdl.residuals("anscombe")
+    assert r.shape == (n,)
+    assert np.all(np.isfinite(r))
+
+
+def test_anscombe_inverse_gaussian_matches_formula() -> None:
+    rng = np.random.default_rng(0)
+    n = 200
+    X = pd.DataFrame({"x": rng.uniform(0.1, 1.0, size=n)})
+    y = rng.uniform(0.5, 1.5, size=n)
+    mdl = GAM(family="inverse_gaussian")
+    mdl.add_feature(name="x", type="linear")
+    mdl.fit(X, y, max_its=20)
+
+    mu = mdl._eval_inv_link(mdl._num_features * mdl.f_bar)
+    expected = (np.log(y) - np.log(mu)) / np.sqrt(mu * mdl.dispersion())
+    np.testing.assert_allclose(mdl.residuals("anscombe"), expected, rtol=1e-10)
+
+
+def test_plot_residuals_accepts_anscombe(normal_fit: GAM) -> None:
+    fig = normal_fit.plot_residuals(kind="anscombe")
+    assert len(fig.axes) == 2


### PR DESCRIPTION
Implements the family-specific variance-stabilizing transformation
A(t) = integral V(s)^(-1/3) ds, which makes residuals approximately
standard-normal under correct model specification (McCullagh &
Nelder 1989 Sec 2.4.1, Wood 2017 Sec 3.1.7).

Per-family forms:
  - normal:           (y - mu) / sqrt(phi)         [== Pearson]
  - binomial(m):      sqrt(m) * (A(y/m) - A(mu)) / [mu(1-mu)]^(1/6)
                      / sqrt(phi), with A from the regularized
                      incomplete beta function with parameters
                      (2/3, 2/3) (scipy.special.betainc + beta).
  - poisson:          (3/2) * (y^(2/3) - mu^(2/3))
                      / mu^(1/6) / sqrt(phi)
  - gamma:            3 * (y^(1/3) - mu^(1/3)) / mu^(1/3) / sqrt(phi)
  - inverse_gaussian: (log y - log mu) / sqrt(mu * phi)

plot_residuals() also accepts kind="anscombe" via the extended
Literal.

Tests:
  - test_anscombe_normal_equals_pearson: collapses correctly.
  - test_anscombe_poisson_matches_formula: numeric match against
    the explicit formula.
  - test_anscombe_gamma_matches_formula: same, with dispersion=1.0
    pinned to bypass _gamma_dispersion's finicky Newton.
  - test_anscombe_binomial_with_ccs_finite: smoke for the
    incomplete-beta branch.
  - test_anscombe_inverse_gaussian_matches_formula: numeric match.
  - test_plot_residuals_accepts_anscombe: plotting smoke.

Move the Anscombe item from To-do to Done in the gamdist.py header.

126/126 pytest, ruff/mypy clean.