### PR TITLE
fix: replace damped Newton in _gamma_dispersion with scipy.optimize.brentq

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,17 @@
+2026-04-25 : Fix _gamma_dispersion convergence
+- Replace the damped-Newton solver in _gamma_dispersion (fixed step
+  beta=0.1, max_its=100, tol=1e-6) with scipy.optimize.brentq on a
+  wide bracket. The likelihood equation
+      2 * num_obs * (log nu - psi(nu)) - dof / nu = dev
+  is monotonic in nu and has a unique positive root for any inputs
+  with dev > 0 and 2 * num_obs > dof, so a bracket-based root
+  finder converges reliably. The previous Newton iteration ran out
+  of iterations on perfectly reasonable inputs (e.g. dof=3, dev=10,
+  num_obs=50), causing GAM(family="gamma").dispersion() to spuriously
+  raise ValueError after fitting.
+- The function now raises ValueError only when the equation has no
+  positive root (e.g. dev <= 0).
+
 2026-04-25 : Anscombe residuals
 - Add kind="anscombe" to GAM.residuals() (and GAM.plot_residuals()).
   Implements the family-specific variance-stabilizing transformation

--- a/gamdist/gamdist.py
+++ b/gamdist/gamdist.py
@@ -31,6 +31,7 @@ import numpy as np
 import numpy.typing as npt
 import pandas as pd
 import scipy.linalg as linalg
+import scipy.optimize as optimize
 import scipy.special as special
 import scipy.stats as stats
 
@@ -183,42 +184,48 @@ def _plot_convergence(
 def _gamma_dispersion(dof: float, dev: float, num_obs: int) -> float:
     """Gamma dispersion.
 
-    This function estimates the dispersion of a Gamma family with p
-    degrees of freedom and deviance D, and n observations. The
-    dispersion nu is that number satisfying
-      2*n * (log nu - psi(nu)) - p / nu = D
+    Solves the gamma likelihood equation
+        2 * num_obs * (log nu - psi(nu)) - dof / nu = dev
+    for nu. The left-hand side minus the right-hand side is monotonically
+    decreasing in nu and crosses zero exactly once for valid inputs
+    (``dev > 0`` and ``2 * num_obs > dof``), so Brent's method on a wide
+    bracket converges reliably.
 
-    We use Newton's method with a learning rate to solve this nonlinear
-    equation.
+    The previous damped-Newton implementation used a fixed step of 0.1
+    and tol=1e-6 and ran out of iterations on perfectly reasonable
+    inputs (e.g. ``dof=3, dev=10, num_obs=50``).
 
     Parameters
     ----------
-     dof : float
-         Degrees of freedom
-     dev : float
-         Deviance
-     num_obs : int
-         Number of observations
+    dof : float
+        Effective degrees of freedom of the fitted model.
+    dev : float
+        Total deviance.
+    num_obs : int
+        Number of observations.
 
     Returns
     -------
-     nu : float
-         Estimated dispersion
-    """
-    beta = 0.1
-    tol = 1e-6
-    max_its = 100
+    nu : float
+        The shape-parameter MLE. (The function name is a misnomer kept
+        for backwards compatibility -- callers expect the shape, which
+        is the inverse of the dispersion phi.)
 
-    nu = 1.
-    for i in range(max_its):
-        num = 2. * num_obs * (np.log(nu) - special.psi(nu)) - dof / nu - dev
-        denom = 2. * num_obs * (1. / nu - special.polygamma(1, nu)) + dof / (nu * nu)
-        dnu = num / denom
-        nu -= dnu * beta
-        if abs(dnu) < tol:
-            return nu
-    else:
-        raise ValueError('Could not estimate gamma dispersion.')
+    Raises
+    ------
+    ValueError
+        When the equation has no positive root for the given inputs.
+    """
+    if dev <= 0.0:
+        raise ValueError("Could not estimate gamma dispersion: non-positive deviance.")
+
+    def f(nu: float) -> float:
+        return 2.0 * num_obs * (np.log(nu) - special.psi(nu)) - dof / nu - dev
+
+    lo, hi = 1e-8, 1e8
+    if f(lo) * f(hi) > 0:
+        raise ValueError("Could not estimate gamma dispersion: no sign change in bracket.")
+    return float(optimize.brentq(f, lo, hi, xtol=1e-10, rtol=1e-10))
 
 class GAM:
     def __init__(

--- a/tests/test_internals.py
+++ b/tests/test_internals.py
@@ -8,19 +8,46 @@ from pathlib import Path
 import numpy as np
 import pandas as pd
 import pytest
+import scipy.special as special
 
 from gamdist import GAM
 from gamdist.gamdist import _gamma_dispersion, _plot_convergence
 from tests.conftest import generate_covariate_class_data
 
 
-def test_gamma_dispersion_diverges_raises() -> None:
-    # The Newton iteration in _gamma_dispersion uses a fixed beta=0.1 step
-    # and tol=1e-6, which often fails to converge in 100 iterations. We
-    # exercise the explicit failure path here; the success path is touched
-    # implicitly by GAM.dispersion() in the gamma family tests.
+def test_gamma_dispersion_solves_likelihood_equation() -> None:
+    # Inputs that the previous damped-Newton implementation could not
+    # solve in 100 iterations. The brentq-based solver returns the unique
+    # root of f(nu) = 2*n*(log nu - psi(nu)) - dof/nu - dev.
+    nu = _gamma_dispersion(dof=3.0, dev=10.0, num_obs=50)
+    assert nu > 0
+    f_at_nu = (
+        2.0 * 50 * (np.log(nu) - special.psi(nu)) - 3.0 / nu - 10.0
+    )
+    assert abs(f_at_nu) < 1e-6
+
+
+def test_gamma_dispersion_zero_deviance_raises() -> None:
+    # With dev=0 the likelihood equation has no positive root (the LHS is
+    # strictly positive for all finite nu).
     with pytest.raises(ValueError, match="Could not estimate gamma dispersion"):
-        _gamma_dispersion(dof=3.0, dev=10.0, num_obs=50)
+        _gamma_dispersion(dof=3.0, dev=0.0, num_obs=50)
+
+
+def test_gamma_dispersion_via_gam_succeeds() -> None:
+    # End-to-end: fitting a gamma model and calling .dispersion() must
+    # now succeed. The previous implementation raised ValueError on this
+    # exact data.
+    rng = np.random.default_rng(0)
+    n = 100
+    X = pd.DataFrame({"x": rng.uniform(0.1, 0.5, size=n)})
+    y = rng.gamma(shape=4.0, scale=0.5, size=n)
+    mdl = GAM(family="gamma")
+    mdl.add_feature(name="x", type="linear")
+    mdl.fit(X, y, max_its=30)
+    phi = mdl.dispersion()
+    assert np.isfinite(phi)
+    assert phi > 0
 
 
 def test_plot_convergence_uses_agg_backend() -> None:


### PR DESCRIPTION
_gamma_dispersion solves the gamma likelihood equation

    2 * num_obs * (log nu - psi(nu)) - dof / nu = dev

for the shape parameter nu. The previous implementation used Newton's
method with a fixed damping factor of 0.1, max_its=100, and tol=1e-6.
For perfectly reasonable inputs -- e.g. (dof=3, dev=10, num_obs=50) --
this configuration ran out of iterations and raised
"Could not estimate gamma dispersion", which propagated up through
GAM(family="gamma").dispersion() and broke any downstream metric
(aic, gcv, ubre, residuals, etc.) on a fitted gamma model.

The LHS minus the RHS is monotonically decreasing in nu and crosses
zero exactly once for valid inputs (dev > 0, 2 * num_obs > dof), so
brentq with a wide bracket [1e-8, 1e8] converges reliably without
requiring careful step-size tuning.

ValueError is now raised only when the equation has no positive root
(e.g. dev <= 0 from a perfect fit, or a degenerate configuration with
no sign change in the bracket).

Tests:
  - test_gamma_dispersion_solves_likelihood_equation: the previous
    failure case (3, 10, 50) now returns a finite nu, and f(nu) is
    near zero within solver tolerance.
  - test_gamma_dispersion_zero_deviance_raises: degenerate input
    still raises with the same message prefix.
  - test_gamma_dispersion_via_gam_succeeds: end-to-end -- fit a gamma
    GAM and call .dispersion() without it raising.

The previously-existing test_gamma_dispersion_diverges_raises (which
asserted the old failure mode on a normal input) is replaced by the
positive test above, since that input no longer fails.

128/128 pytest, ruff/mypy clean.