### PR TITLE
feat: add GAM.plot_residuals_vs_predictor()

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,11 @@
+2026-04-25 : Residuals vs predictor plots
+- Add GAM.plot_residuals_vs_predictor(predictor, kind=..., name=...).
+  Scatter of residuals against an arbitrary 1-D array of length
+  num_obs. Useful for diagnosing unmodeled non-linearities (a
+  predictor already in the model) or assessing whether to add a new
+  predictor (one not currently in the model). Categorical
+  (string/object) predictors get an automatic categorical x-axis.
+
 2026-04-25 : Fix _gamma_dispersion convergence
 - Replace the damped-Newton solver in _gamma_dispersion (fixed step
   beta=0.1, max_its=100, tol=1e-6) with scipy.optimize.brentq on a

--- a/gamdist/gamdist.py
+++ b/gamdist/gamdist.py
@@ -68,16 +68,14 @@ FeatureType = Literal["categorical", "linear", "spline"]
 # - Interactions
 # - Runtime optimization (Cython)
 # - Fit in parallel
-# - Residuals
-#   - Plot residuals against each predictor / unused predictors
 #
 # Done:
 # - Implement Gaussian, Binomial, Poisson, Gamma, Inv Gaussian,
 # - Plot splines
 # - Deviance (on training set and test set), AIC, AICc, BIC, R^2,
 #   Dispersion, GCV, UBRE
-# - Response, Pearson, deviance, Anscombe residuals;
-#   residual-vs-fitted and QQ plots
+# - Response, Pearson, deviance, Anscombe residuals; residual-vs-fitted,
+#   residual-vs-predictor, and QQ plots
 # - Write documentation
 # - Check implementation of Gamma dispersion
 # - Implement probit, complementary log-log links.
@@ -1209,6 +1207,57 @@ class GAM:
         stats.probplot(res, plot=ax2)
         ax2.set_title("Normal Q-Q")
 
+        fig.tight_layout()
+        return fig
+
+    def plot_residuals_vs_predictor(
+        self,
+        predictor: npt.ArrayLike,
+        *,
+        kind: Literal["response", "pearson", "deviance", "anscombe"] = "deviance",
+        name: str | None = None,
+    ) -> Any:
+        """Plot residuals against a predictor.
+
+        Useful for diagnosing fit adequacy: a clear pattern (curvature,
+        funnel shape, etc.) when ``predictor`` is a feature already in
+        the model suggests an unmodeled non-linearity or
+        heteroscedasticity. The same plot for a predictor *not* in the
+        model is a quick check on whether to add it.
+
+        Parameters
+        ----------
+        predictor : array-like of shape ``(n_obs,)``
+            Predictor values for each training observation. Must match
+            the length of the training data used to fit this model.
+            Categorical (string / object) predictors are plotted as a
+            categorical x-axis.
+        kind : ``"response"``, ``"pearson"``, ``"deviance"``, or ``"anscombe"``
+            Forwarded to ``residuals()``.
+        name : str, optional
+            Label for the x-axis and title.
+
+        Returns
+        -------
+        fig : matplotlib.figure.Figure
+        """
+        import matplotlib.pyplot as plt
+
+        res = self.residuals(kind)
+        pred = np.asarray(predictor)
+        if pred.shape != (self._num_obs,):
+            raise ValueError(
+                f"predictor has shape {pred.shape}, "
+                f"expected ({self._num_obs},) to match training data"
+            )
+
+        label = name if name is not None else "predictor"
+        fig, ax = plt.subplots(figsize=(6, 4))
+        ax.scatter(pred, res, s=10, alpha=0.6)
+        ax.axhline(0.0, color="grey", linewidth=0.5)
+        ax.set_xlabel(label)
+        ax.set_ylabel(f"{kind.capitalize()} residual")
+        ax.set_title(f"Residuals vs {label}")
         fig.tight_layout()
         return fig
 

--- a/tests/test_residuals.py
+++ b/tests/test_residuals.py
@@ -177,3 +177,43 @@ def test_anscombe_inverse_gaussian_matches_formula() -> None:
 def test_plot_residuals_accepts_anscombe(normal_fit: GAM) -> None:
     fig = normal_fit.plot_residuals(kind="anscombe")
     assert len(fig.axes) == 2
+
+
+def test_plot_residuals_vs_predictor_smoke(normal_fit: GAM) -> None:
+    rng = np.random.default_rng(0)
+    predictor = rng.normal(size=normal_fit._num_obs)
+    fig = normal_fit.plot_residuals_vs_predictor(predictor, name="x")
+    assert len(fig.axes) == 1
+    ax = fig.axes[0]
+    assert ax.get_title() == "Residuals vs x"
+    assert ax.get_xlabel() == "x"
+
+
+def test_plot_residuals_vs_predictor_default_label(normal_fit: GAM) -> None:
+    predictor = np.linspace(0.0, 1.0, normal_fit._num_obs)
+    fig = normal_fit.plot_residuals_vs_predictor(predictor)
+    ax = fig.axes[0]
+    # No name supplied -> generic label.
+    assert ax.get_xlabel() == "predictor"
+    assert ax.get_title() == "Residuals vs predictor"
+
+
+def test_plot_residuals_vs_predictor_categorical(normal_fit: GAM) -> None:
+    rng = np.random.default_rng(0)
+    predictor = rng.choice(np.array(["a", "b", "c"]), size=normal_fit._num_obs)
+    fig = normal_fit.plot_residuals_vs_predictor(predictor, name="group")
+    # matplotlib auto-creates a categorical x-axis; just smoke-test that
+    # the figure exists and the title carries the name.
+    assert fig.axes[0].get_title() == "Residuals vs group"
+
+
+def test_plot_residuals_vs_predictor_shape_mismatch_raises(normal_fit: GAM) -> None:
+    bad = np.zeros(normal_fit._num_obs + 1)
+    with pytest.raises(ValueError, match="expected"):
+        normal_fit.plot_residuals_vs_predictor(bad)
+
+
+def test_plot_residuals_vs_predictor_uses_chosen_kind(normal_fit: GAM) -> None:
+    predictor = np.arange(normal_fit._num_obs, dtype=float)
+    fig = normal_fit.plot_residuals_vs_predictor(predictor, kind="pearson")
+    assert fig.axes[0].get_ylabel() == "Pearson residual"


### PR DESCRIPTION
Closes the last residuals item on the to-do list at the top of
gamdist.py: residuals-vs-predictor plots, useful for two diagnostic
questions:

  - For a feature already in the model: is there an unmodeled
    non-linearity or heteroscedasticity? A clear pattern in the
    scatter signals "yes".
  - For a predictor not in the model: should it be added? A pattern
    here suggests yes.

Both cases use the same scatter plot. The new method takes a 1-D
array of length num_obs (so users can plot against either a feature
column or any external variable they care about), an optional
``name`` for the axis/title label, and ``kind`` forwarded to
``residuals()``. matplotlib's categorical-axis support handles
string/object predictors automatically.

Tests cover: numeric and categorical predictors, missing-name default
("predictor"), shape-mismatch ValueError, and y-axis label tracking
the requested residual kind.

Move "Plot residuals against each predictor / unused predictors"
from the To-do list to the Done list.

133/133 pytest, ruff/mypy clean.