### PR TITLE
feat: group lasso for categorical features (variable selection)

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,24 @@
+2026-04-25 : Group lasso for categorical features
+- _CategoricalFeature now accepts
+      regularization={"group_lasso": {"coef": lambda}}
+  alongside the existing l1/l2/network_lasso options.
+- The penalty added to the cvxpy objective is
+      lambda * ||A q||_2  =  lambda * sqrt(q^T diag(ccs) q)
+  i.e. the L2 norm of the per-feature contribution vector. Driving
+  this to zero zeros out the entire feature, giving categorical-
+  variable selection: either every level participates in the model
+  or none does. Lambda is scaled by the global `smoothing` argument
+  (matching the other categorical penalties).
+- Persisted across save/load. Older pickles default has_group_lasso
+  to False on load.
+- Tests cover: lambda=0 parity with the unpenalized solve, huge
+  lambda zeroing the parameter vector, intermediate-lambda shrinkage,
+  smoothing scaling, save/load round-trip, missing-coef error path,
+  and an end-to-end variable-selection test (a noise feature shrinks
+  to <10% of the signal feature's norm).
+- Linear / spline group lasso and the l_inf variant remain on the
+  to-do list for follow-up.
+
 2026-04-25 : Parallel feature optimization
 - GAM.fit() now accepts an n_jobs argument. With n_jobs > 1 (or
   n_jobs=-1 for os.cpu_count()), the per-feature primal step in each

--- a/gamdist/categorical_feature.py
+++ b/gamdist/categorical_feature.py
@@ -54,7 +54,8 @@ class _CategoricalFeature(_Feature):
             Name for feature, used to make plots.
         regularization : dict
             Description of regularization terms (``l1``, ``l2``,
-            ``network_lasso``). See the package README for details.
+            ``group_lasso``, ``network_lasso``). See the package
+            README for details.
         load_from_file : str
             Pickle path used to restore parameters. If specified,
             other parameters are ignored.
@@ -75,10 +76,12 @@ class _CategoricalFeature(_Feature):
         self._has_l1 = False
         self._has_l2 = False
         self._has_network_lasso = False
+        self._has_group_lasso = False
         self._has_prior = False
         self._coef1: float | dict[Any, float] = 0.0
         self._coef2: float | dict[Any, float] = 0.0
         self._lambda_network_lasso: float = 0.0
+        self._lambda_group_lasso: float = 0.0
         self._num_edges: int = 0
         if regularization is not None:
             if "l1" in regularization:
@@ -115,6 +118,15 @@ class _CategoricalFeature(_Feature):
                 else:
                     raise ValueError(
                         "Edges not specified for Network Lasso regularization term."
+                    )
+
+            if "group_lasso" in regularization:
+                self._has_group_lasso = True
+                if "coef" in regularization["group_lasso"]:
+                    self._lambda_group_lasso = float(regularization["group_lasso"]["coef"])
+                else:
+                    raise ValueError(
+                        "No coefficient specified for group_lasso regularization term."
                     )
 
             if (self._has_l1 or self._has_l2) and "prior" in regularization:
@@ -173,6 +185,9 @@ class _CategoricalFeature(_Feature):
         self._lambda2 = np.zeros(self._num_categories)
         if self._has_l2:
             self._lambda2 = self._compute_lambda(self._coef2, smoothing)
+
+        if self._has_group_lasso:
+            self._lambda_group_lasso *= smoothing
 
         if (self._has_l1 or self._has_l2) and self._has_prior:
             prior_vec = np.zeros(self._num_categories)
@@ -235,6 +250,7 @@ class _CategoricalFeature(_Feature):
             "has_l1": self._has_l1,
             "has_l2": self._has_l2,
             "has_network_lasso": self._has_network_lasso,
+            "has_group_lasso": self._has_group_lasso,
             "has_prior": self._has_prior,
             "na_index": self._na_index,
             "x": self.x,
@@ -257,6 +273,8 @@ class _CategoricalFeature(_Feature):
             mv["num_edges"] = self._num_edges
             mv["D"] = self._D
             mv["lambda_network_lasso"] = self._lambda_network_lasso
+        if self._has_group_lasso:
+            mv["lambda_group_lasso"] = self._lambda_group_lasso
         if self._has_prior:
             mv["prior"] = self._prior
 
@@ -286,6 +304,12 @@ class _CategoricalFeature(_Feature):
             self._num_edges = mv["num_edges"]
             self._D = mv["D"]
             self._lambda_network_lasso = mv["lambda_network_lasso"]
+        # has_group_lasso was added later; default to False for older pickles.
+        self._has_group_lasso = mv.get("has_group_lasso", False)
+        if self._has_group_lasso:
+            self._lambda_group_lasso = mv["lambda_group_lasso"]
+        else:
+            self._lambda_group_lasso = 0.0
         self._has_prior = mv["has_prior"]
         if self._has_prior:
             self._prior = mv["prior"]
@@ -360,6 +384,19 @@ class _CategoricalFeature(_Feature):
                 s + D @ q >= 0,
                 s - D @ q >= 0,
             ]
+
+        if self._has_group_lasso:
+            # Group lasso on the per-feature contribution vector
+            # f_j = A q in R^n (one entry per observation). Its L2
+            # norm equals sqrt(q^T diag(ccs) q) since A is the
+            # category-indicator matrix; that's the same as the
+            # L2 norm of (sqrt(ccs) elementwise * q). Driving this
+            # to zero zeros out the entire feature, giving
+            # categorical-variable selection.
+            sqrt_ccs = cvx.Constant(np.sqrt(self._ccs))
+            obj = obj + (2.0 / rho) * self._lambda_group_lasso * cvx.norm(
+                cvx.multiply(sqrt_ccs, q), 2
+            )
 
         prob = cvx.Problem(cvx.Minimize(obj), constraints)
         prob.solve(verbose=self._verbose, solver=self._solver)

--- a/gamdist/gamdist.py
+++ b/gamdist/gamdist.py
@@ -65,7 +65,9 @@ FeatureType = Literal["categorical", "linear", "spline"]
 # - Confidence intervals on mu, predictions (probably need to use Bootstrap but can
 #   do so intelligently)
 # - Confidence intervals on model parameters, p-values
-# - Group lasso penalty (l2 norm -- not squared -- or l_\infty norm on f_j(x_j; p_j))
+# - Group lasso penalty for linear and spline features (l2 norm on
+#   f_j(x_j; p_j); categorical is done -- see regularization={"group_lasso": ...})
+# - Group lasso variant with l_\infty norm on f_j(x_j; p_j)
 # - Interactions
 # - Runtime optimization (Cython)
 #

--- a/tests/test_categorical_group_lasso.py
+++ b/tests/test_categorical_group_lasso.py
@@ -1,0 +1,134 @@
+"""Tests for the group_lasso regularization on _CategoricalFeature.
+
+Group lasso on a categorical feature drives the entire per-level
+parameter vector p toward zero, giving categorical-variable selection
+(either every level is in the model or none is). The penalty term is
+``lambda * ||A q||_2 = lambda * sqrt(q^T diag(ccs) q)``.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from gamdist import GAM
+from gamdist.categorical_feature import _CategoricalFeature
+
+
+def test_group_lasso_no_coef_raises() -> None:
+    with pytest.raises(ValueError, match="No coefficient specified for group_lasso"):
+        _CategoricalFeature(name="g", regularization={"group_lasso": {}})
+
+
+def test_group_lasso_smoothing_scales_lambda() -> None:
+    feat = _CategoricalFeature(
+        name="g", regularization={"group_lasso": {"coef": 0.4}}
+    )
+    feat.initialize(np.array(["a", "b", "a"]), smoothing=2.5)
+    assert feat._has_group_lasso
+    assert feat._lambda_group_lasso == pytest.approx(1.0)
+
+
+def test_group_lasso_lambda_zero_matches_unpenalized() -> None:
+    rng = np.random.default_rng(0)
+    x = rng.choice(np.array(["a", "b", "c"]), size=200)
+    fpumz = rng.normal(size=200)
+
+    plain = _CategoricalFeature(name="g")
+    plain.initialize(x)
+    plain.optimize(fpumz, rho=1.0)
+
+    zero = _CategoricalFeature(name="g", regularization={"group_lasso": {"coef": 0.0}})
+    zero.initialize(x)
+    zero.optimize(fpumz, rho=1.0)
+
+    np.testing.assert_allclose(zero.p, plain.p, atol=1e-6)
+
+
+def test_group_lasso_huge_lambda_zeros_parameters() -> None:
+    rng = np.random.default_rng(0)
+    x = rng.choice(np.array(["a", "b", "c"]), size=200)
+    fpumz = rng.normal(size=200)
+    feat = _CategoricalFeature(
+        name="g", regularization={"group_lasso": {"coef": 1e6}}
+    )
+    feat.initialize(x)
+    feat.optimize(fpumz, rho=1.0)
+    np.testing.assert_allclose(feat.p, 0.0, atol=1e-6)
+
+
+def test_group_lasso_intermediate_lambda_shrinks() -> None:
+    # Predictions should be strictly smaller in magnitude under a
+    # moderate group lasso penalty than without.
+    rng = np.random.default_rng(0)
+    x = rng.choice(np.array(["a", "b", "c"]), size=200)
+    fpumz = rng.normal(size=200) + 2.0  # strong signal so the unpenalized fit isn't tiny
+
+    unpenalized = _CategoricalFeature(name="g")
+    unpenalized.initialize(x)
+    unpenalized.optimize(fpumz, rho=1.0)
+
+    moderate = _CategoricalFeature(
+        name="g", regularization={"group_lasso": {"coef": 0.5}}
+    )
+    moderate.initialize(x)
+    moderate.optimize(fpumz, rho=1.0)
+
+    assert np.linalg.norm(moderate.p) < np.linalg.norm(unpenalized.p)
+
+
+def test_group_lasso_save_load_round_trip(tmp_path: Path) -> None:
+    feat = _CategoricalFeature(
+        name="g", regularization={"group_lasso": {"coef": 0.7}}
+    )
+    feat.initialize(
+        np.array(["a", "b", "a"]),
+        smoothing=2.0,
+        save_flag=True,
+        save_prefix=str(tmp_path / "model"),
+    )
+    feat.p = np.array([0.3, -0.3])
+    feat._save()
+
+    restored = _CategoricalFeature(load_from_file=feat._filename)
+    assert restored._has_group_lasso
+    assert restored._lambda_group_lasso == pytest.approx(1.4)
+    np.testing.assert_allclose(restored.p, feat.p)
+
+
+def test_group_lasso_within_gam_drops_noise_feature() -> None:
+    # Two categorical features. "signal" actually drives y; "noise" does
+    # not. With a moderate group lasso applied to *both*, noise should
+    # shrink much more than signal.
+    rng = np.random.default_rng(2)
+    n = 400
+    signal = rng.choice(np.array(["a", "b", "c"]), size=n)
+    noise = rng.choice(np.array(["x", "y", "z"]), size=n)
+    signal_effects = {"a": 1.5, "b": -1.0, "c": -0.5}
+    y = np.array([signal_effects[s] for s in signal]) + rng.normal(size=n) * 0.1
+    X = pd.DataFrame({"signal": signal, "noise": noise})
+
+    mdl = GAM(family="normal")
+    mdl.add_feature(
+        name="signal",
+        type="categorical",
+        regularization={"group_lasso": {"coef": 0.3}},
+    )
+    mdl.add_feature(
+        name="noise",
+        type="categorical",
+        regularization={"group_lasso": {"coef": 0.3}},
+    )
+    mdl.fit(X, y, max_its=40)
+
+    signal_feat = mdl._features["signal"]
+    noise_feat = mdl._features["noise"]
+    signal_norm = float(np.linalg.norm(signal_feat.p))  # type: ignore[attr-defined]
+    noise_norm = float(np.linalg.norm(noise_feat.p))  # type: ignore[attr-defined]
+    # Signal feature should retain meaningful magnitude; noise should be
+    # heavily shrunk relative to it.
+    assert signal_norm > 0.5
+    assert noise_norm < 0.1 * signal_norm


### PR DESCRIPTION
Adds the canonical use case of group lasso to gamdist: a categorical
feature has one parameter per level, and you typically want either
all of them in the model or none. The penalty

    lambda * ||A q||_2  =  lambda * sqrt(q^T diag(ccs) q)

is the L2 norm of the per-feature contribution vector f_j = A q,
where A is the category-indicator matrix and ccs is the per-category
observation count (or trial count when covariate classes are in
play). Driving this norm to zero zeros out the entire feature.

API: slot into the existing regularization= dict alongside l1/l2/
network_lasso, e.g.

    mdl.add_feature(
        name="g",
        type="categorical",
        regularization={"group_lasso": {"coef": 0.3}},
    )

Implementation:
  - Parsed in _CategoricalFeature.__init__ (sets _has_group_lasso /
    _lambda_group_lasso); raises if "coef" missing, matching the
    pattern of l1/l2/network_lasso.
  - Scaled by the global `smoothing` in initialize().
  - Added to the cvxpy objective as
        (2/rho) * lambda * cvx.norm(cvx.multiply(sqrt(ccs), q), 2)
    The (2/rho) scaling matches how l1/network_lasso enter the same
    objective. CLARABEL handles the resulting SOCP natively.
  - Persisted in _save / _load. Older pickles default
    has_group_lasso=False on load.

Tests (new file tests/test_categorical_group_lasso.py):
  - test_group_lasso_no_coef_raises
  - test_group_lasso_smoothing_scales_lambda
  - test_group_lasso_lambda_zero_matches_unpenalized
  - test_group_lasso_huge_lambda_zeros_parameters
  - test_group_lasso_intermediate_lambda_shrinks
  - test_group_lasso_save_load_round_trip
  - test_group_lasso_within_gam_drops_noise_feature: end-to-end
    variable selection -- two categorical features, one carries the
    signal and the other is pure noise; with the same moderate
    lambda on both, the noise feature shrinks to <10% of the
    signal feature's norm.

Update the to-do at the top of gamdist.py: split the original
"group lasso" item into "linear/spline" and "l_inf variant", which
remain open.

144/144 pytest, ruff/mypy clean.