### PR TITLE
docs: add design philosophy / North Star to CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,19 @@
 
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
+## Design philosophy (North Star)
+
+gamdist exists to fit the **zoo** of supervised-learning models that fall under the GLM/GAM umbrella: binary, continuous, or count outcomes paired with continuous, categorical, or spline-transformed features, with arbitrary regularization (ridge, l1, group lasso, curvature penalties, …) attached to whichever terms want it.
+
+Every such model is a single convex optimization problem — but the joint Hessian is a nightmare to derive and solve as one monolith. ADMM (per Chu, Keshavarz, & Boyd) is what makes the zoo tractable: it splits the problem into a per-feature primal step plus a per-outcome proximal step, coordinated by dual variables. Parallelism is a nice side effect; **the real prize is modularity** — outcomes, features, and regularizers are independent components that mix and match in any combination without anyone needing to know about the others.
+
+Practical consequences for development:
+
+- **Convexity is the constraint that buys us everything.** Non-convex links/families compromise the guarantees ADMM gives us; treat them as second-class (the existing non-canonical fallbacks already are). Don't add features, penalties, or proximal operators that break convexity of the per-component subproblems.
+- **Keep the seams clean.** The `_Feature` interface (`initialize`/`optimize`/`compute_dual_tol`/`num_params`/`dof`/`predict`/`_save`/`_load`) and the `(family, link)` → proximal-operator dispatch are the modular boundaries. New feature types or new outcome distributions should plug in without the other side learning anything new.
+- **New regularizers belong inside a feature's `optimize` step**, not bolted onto the global loop — that's how ADMM keeps them composable.
+- Resist designs that route information across the seams (a feature that needs to know the family, a proximal operator that needs to know which features exist, etc.); if a change seems to require it, flag the tension before implementing.
+
 ## Python version
 
 Requires **Python 3.11+**. Code uses `from __future__ import annotations` and full PEP 484 type hints throughout. The package was modernized from Python 2 in v0.2.0; see `changelog.txt`. There is no `setup.py` — packaging is via `pyproject.toml` (hatchling). Real third-party deps are `numpy`, `scipy`, `matplotlib`, `cvxpy`, `pandas`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,9 +10,9 @@ Every such model is a single convex optimization problem — but the joint Hessi
 
 Practical consequences for development:
 
-- **Convexity is the constraint that buys us everything.** Non-convex links/families compromise the guarantees ADMM gives us; treat them as second-class (the existing non-canonical fallbacks already are). Don't add features, penalties, or proximal operators that break convexity of the per-component subproblems.
+- **Convexity is non-negotiable.** Every per-component subproblem must be convex; non-convex (family, link) combinations and non-convex penalties are not supported. The right behavior is to detect such combinations up front and raise — don't lean on `scipy.optimize.minimize_scalar` or other generic solvers as a way to quietly admit non-convex problems. (The existing non-canonical fallback in `proximal_operators.py` predates this principle and is on the audit list, not a pattern to extend.)
 - **Keep the seams clean.** The `_Feature` interface (`initialize`/`optimize`/`compute_dual_tol`/`num_params`/`dof`/`predict`/`_save`/`_load`) and the `(family, link)` → proximal-operator dispatch are the modular boundaries. New feature types or new outcome distributions should plug in without the other side learning anything new.
-- **New regularizers belong inside a feature's `optimize` step**, not bolted onto the global loop — that's how ADMM keeps them composable.
+- **Regularizers live inside a feature's `optimize` step**, not in the global ADMM loop. `gamdist.py`'s `fit()` / `_optimize` only see `fpumz` and `rho` and never touch a penalty coefficient. Each feature scales its own coefficients by `smoothing` in `initialize()` and adds the penalty to its own subproblem (linear: ridge in the closed-form solve; categorical: L1 / L2 / network-lasso / group-lasso in the cvxpy program; spline: `Omega` curvature folded into the Cholesky factor). New penalties go in the same place.
 - Resist designs that route information across the seams (a feature that needs to know the family, a proximal operator that needs to know which features exist, etc.); if a change seems to require it, flag the tension before implementing.
 
 ## Python version

--- a/README.md
+++ b/README.md
@@ -20,6 +20,28 @@ Supported families: `normal`, `binomial`, `poisson`, `gamma`,
 Supported links: `identity`, `logistic`, `probit`,
 `complementary_log_log`, `log`, `reciprocal`, `reciprocal_squared`.
 
+## Feature types and regularization
+
+Three feature types are available, each with its own set of penalties
+applied inside the per-feature ADMM step:
+
+- **`linear`** — continuous feature with a single coefficient. Supports
+  ridge (`l2`).
+- **`categorical`** — per-level offset for a categorical feature.
+  Supports `l1`, `l2`, group lasso (`group_lasso`) for variable
+  selection, and **network lasso** (`network_lasso`) for clustering
+  connected categories to identical coefficients.
+- **`spline`** — cubic regression spline with an integrated curvature
+  penalty. Smoothing is set via `rel_dof`, the target effective degrees
+  of freedom.
+
+The network lasso is a good illustration of why the modular design
+matters. Pass an `edges` DataFrame describing which categories should
+have similar coefficients (neighboring counties, related products,
+friends in a social graph), and the categorical feature's optimization
+step adds an L1 penalty on the edge differences. No other component of
+the model needs to change.
+
 ## Install
 
 Requires Python 3.11+. With [uv][uv]:
@@ -55,6 +77,44 @@ mdl.fit(X, y)
 
 mdl.summary()
 yhat = mdl.predict(X)
+```
+
+### Network lasso on a spatial categorical
+
+A second example showing the modular regularization story: 12 regions
+arranged in a chain, with a true effect that drifts smoothly along the
+chain. The network lasso shrinks neighboring regions toward identical
+coefficients without any change to the rest of the model.
+
+```python
+import numpy as np
+import pandas as pd
+from gamdist import GAM
+
+regions = [f"r{i:02d}" for i in range(12)]
+true_effect = dict(zip(regions, np.linspace(-1.0, 1.0, len(regions))))
+
+# Edges describe the adjacency graph; column names "country1" / "country2"
+# are required by the current API, with an optional "weight" column.
+edges = pd.DataFrame(
+    {"country1": regions[:-1], "country2": regions[1:], "weight": 1.0}
+)
+
+n = 2000
+X = pd.DataFrame({"region": np.random.choice(regions, size=n)})
+y = (
+    np.array([true_effect[r] for r in X["region"]])
+    + np.random.normal(scale=0.3, size=n)
+)
+
+mdl = GAM(family="normal")
+mdl.add_feature(
+    name="region",
+    type="categorical",
+    regularization={"network_lasso": {"coef": 1.0, "edges": edges}},
+)
+mdl.fit(X, y)
+mdl.summary()
 ```
 
 ## Development

--- a/README.md
+++ b/README.md
@@ -129,6 +129,25 @@ uv run ruff check gamdist tests               # lint
 CI runs all of the above on Python 3.11 and 3.12 (see
 `.github/workflows/ci.yml`).
 
+## Extending gamdist
+
+The modular design means new components plug in along well-defined
+seams without touching the rest of the system:
+
+- **New outcome distribution / link** — add a proximal operator entry
+  in `gamdist/proximal_operators.py` for the `(family, link)` pair.
+  Nothing on the feature side changes.
+- **New feature type** — subclass `_Feature` (see `gamdist/feature.py`)
+  and implement the standard interface (`initialize`, `optimize`,
+  `compute_dual_tol`, `num_params`, `dof`, `predict`, `_save`,
+  `_load`). The ADMM loop in `gamdist.py` doesn't need to know.
+- **New regularizer** — add it inside a feature's `optimize` step
+  (alongside the existing L1 / L2 / group-lasso / network-lasso /
+  curvature terms), scaled by `smoothing` in `initialize`. The global
+  loop never sees a penalty coefficient.
+
+Every per-component subproblem must be convex.
+
 ## Caveats
 
 - The package uses `pickle` for save/load and is **not designed for

--- a/README.md
+++ b/README.md
@@ -1,8 +1,19 @@
 # gamdist
 
-Generalized Additive Models fit via the Alternating Direction Method of
-Multipliers (ADMM), following the per-feature decomposition of
-[Chu, Keshavarz, Boyd][gamadmm].
+A modular toolkit for the GLM/GAM zoo — binary, continuous, or count
+outcomes; continuous, categorical, or spline-transformed features;
+arbitrary regularization (ridge, L1, group lasso, network lasso,
+curvature penalties) attached to whichever terms want it. Every model is
+a single convex optimization problem.
+
+The joint Hessian for that problem is intractable to derive and solve as
+a monolith. The ADMM decomposition of [Chu, Keshavarz, Boyd][gamadmm]
+makes the zoo tractable by splitting the problem into a per-feature
+primal step plus a per-outcome proximal step coordinated by dual
+variables. Parallelism is a side effect; the real prize is
+**modularity** — outcomes, features, and regularizers are independent
+components that mix and match in any combination, with new ones plugging
+in without disturbing the rest.
 
 Supported families: `normal`, `binomial`, `poisson`, `gamma`,
 `exponential` (= gamma with dispersion 1), `inverse_gaussian`.
@@ -64,9 +75,14 @@ CI runs all of the above on Python 3.11 and 3.12 (see
   untrusted input**.
 - `confidence_intervals()` is not yet implemented and raises
   `NotImplementedError`.
-- Some non-canonical family/link combinations are non-convex; the
-  ADMM iteration is not guaranteed to converge there. In particular,
-  gamma + reciprocal can produce non-positive `mu` on small datasets.
+- Convexity of every per-component subproblem is a hard requirement.
+  Non-convex (family, link) combinations are out of scope; the existing
+  `scipy.optimize.minimize_scalar` fallback for non-canonical pairs
+  predates this principle and is scheduled for removal (see
+  [issue #19][issue19]).
+- Gamma + reciprocal can produce non-positive `mu` on small datasets
+  (numerical edge case in an otherwise supported combination).
 
 [gamadmm]: https://stanford.edu/~boyd/papers/admm/gam.html
 [uv]: https://github.com/astral-sh/uv
+[issue19]: https://github.com/rwilson4/gamdist/issues/19


### PR DESCRIPTION
Captures the modularity-via-ADMM principle that guides what kinds of
changes belong in the codebase: outcomes, features, and regularizers as
independent components, with convexity of the per-component subproblems
as the constraint that keeps the decomposition sound.

https://claude.ai/code/session_01SaogsGNzg3uciuLKydPceH