### PR TITLE
Bug fixes: closes #20, #37, #40, #41, #42, #43

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,10 +94,8 @@ from gamdist import GAM
 regions = [f"r{i:02d}" for i in range(12)]
 true_effect = dict(zip(regions, np.linspace(-1.0, 1.0, len(regions))))
 
-# Edges describe the adjacency graph; column names "country1" / "country2"
-# are required by the current API, with an optional "weight" column.
 edges = pd.DataFrame(
-    {"country1": regions[:-1], "country2": regions[1:], "weight": 1.0}
+    {"node1": regions[:-1], "node2": regions[1:], "weight": 1.0}
 )
 
 n = 2000

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,12 @@
+2026-04-26 : Reject l1 regularization on linear features
+- _LinearFeature.__init__ now raises ValueError if the user passes
+  regularization={"l1": ...}. The L1 coefficient was previously stored
+  but silently dropped in optimize() — users got a plain ridge / no-
+  penalty fit and no warning. The error message points at the
+  categorical-feature L1 path for users who need L1 today, and at
+  issue #53 for the follow-up that will implement L1 properly on
+  linear features. Closes #20.
+
 2026-04-26 : Damped Newton fallback for inv_gaussian + reciprocal_squared prox
 - _prox_inv_gaussian_reciprocal_squared_scalar previously raised
   ValueError when undamped Newton failed to converge in 100 iterations,

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,13 @@
+2026-04-26 : Damped Newton fallback for inv_gaussian + reciprocal_squared prox
+- _prox_inv_gaussian_reciprocal_squared_scalar previously raised
+  ValueError when undamped Newton failed to converge in 100 iterations,
+  inconsistent with the binomial / poisson canonical-link solvers which
+  fall back to scipy.optimize.minimize_scalar. The prox is convex in
+  eta = z^2 but not in z, so the Newton step in z is not always a
+  descent direction. Now uses damped Newton with backtracking on the
+  objective (matching _prox_binomial_logit_scalar) and falls through to
+  minimize_scalar if Newton can't make progress. Closes #42.
+
 2026-04-26 : Rename network_lasso edge columns country1/country2 to node1/node2
 - _CategoricalFeature now expects the edges DataFrame for
   regularization={"network_lasso": {"edges": ...}} to use the

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,11 @@
+2026-04-26 : Replace assert with raise in proximal-operator validation
+- _prox_normal, _prox_binomial, _prox_poisson, _prox_gamma, and
+  _prox_inv_gaussian previously used `assert inv_link is not None` to
+  validate the required inv_link argument. Under `python -O` assertions
+  are stripped, which would let a None inv_link propagate as a less-
+  clear TypeError deeper in the call. Now raises ValueError with a
+  clear message in all five locations. Closes #41.
+
 2026-04-25 : Group lasso for categorical features
 - _CategoricalFeature now accepts
       regularization={"group_lasso": {"coef": lambda}}

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,9 @@
+2026-04-26 : Validate weights and covariate_class_sizes lengths in fit()
+- GAM.fit() now raises ValueError immediately if `weights` or
+  `covariate_class_sizes`, when provided, do not match len(y). Previously
+  the mismatch propagated as a confusing broadcasting failure deep
+  inside deviance computation. Closes #40.
+
 2026-04-26 : Replace assert with raise in proximal-operator validation
 - _prox_normal, _prox_binomial, _prox_poisson, _prox_gamma, and
   _prox_inv_gaussian previously used `assert inv_link is not None` to

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,13 @@
+2026-04-26 : Rename network_lasso edge columns country1/country2 to node1/node2
+- _CategoricalFeature now expects the edges DataFrame for
+  regularization={"network_lasso": {"edges": ...}} to use the
+  domain-neutral column names "node1" and "node2" (with the existing
+  optional "weight"). The previous names hardcoded a country-pairs
+  use case into a generic feature class. Clean rename, no backwards-
+  compat path for the old names — callers with country-keyed edges
+  need a one-line update. README example and tests updated.
+  Closes #37.
+
 2026-04-26 : Persist network_lasso edges DataFrame across save/load
 - _CategoricalFeature._save now stores the original edges DataFrame
   alongside the derived difference matrix D, and _load restores it.

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,11 @@
+2026-04-26 : Persist network_lasso edges DataFrame across save/load
+- _CategoricalFeature._save now stores the original edges DataFrame
+  alongside the derived difference matrix D, and _load restores it.
+  Older pickles only stored D and silently dropped self._edges; loaded
+  models now keep the adjacency for inspection or re-fitting. Older
+  pickles without the new key continue to load (D-only path), matching
+  the same older-pickle handling used for has_group_lasso. Closes #43.
+
 2026-04-26 : Validate weights and covariate_class_sizes lengths in fit()
 - GAM.fit() now raises ValueError immediately if `weights` or
   `covariate_class_sizes`, when provided, do not match len(y). Previously

--- a/gamdist/categorical_feature.py
+++ b/gamdist/categorical_feature.py
@@ -111,10 +111,10 @@ class _CategoricalFeature(_Feature):
                     self._edges = regularization["network_lasso"]["edges"]
                     self._num_edges, _ = self._edges.shape
                     for _, row in self._edges.iterrows():
-                        if row["country1"] not in self._categories:
-                            self._categories.append(row["country1"])
-                        if row["country2"] not in self._categories:
-                            self._categories.append(row["country2"])
+                        if row["node1"] not in self._categories:
+                            self._categories.append(row["node1"])
+                        if row["node2"] not in self._categories:
+                            self._categories.append(row["node2"])
                 else:
                     raise ValueError(
                         "Edges not specified for Network Lasso regularization term."
@@ -158,8 +158,8 @@ class _CategoricalFeature(_Feature):
             _, em = self._edges.shape
             ir = 0
             for _, row in self._edges.iterrows():
-                i = self._category_hash[row["country1"]]
-                j = self._category_hash[row["country2"]]
+                i = self._category_hash[row["node1"]]
+                j = self._category_hash[row["node2"]]
                 lmbda = float(row["weight"]) if em >= 3 else 1.0
                 D[ir, i] = lmbda
                 D[ir, j] = -lmbda

--- a/gamdist/categorical_feature.py
+++ b/gamdist/categorical_feature.py
@@ -272,6 +272,7 @@ class _CategoricalFeature(_Feature):
         if self._has_network_lasso:
             mv["num_edges"] = self._num_edges
             mv["D"] = self._D
+            mv["edges"] = self._edges
             mv["lambda_network_lasso"] = self._lambda_network_lasso
         if self._has_group_lasso:
             mv["lambda_group_lasso"] = self._lambda_group_lasso
@@ -303,6 +304,9 @@ class _CategoricalFeature(_Feature):
         if self._has_network_lasso:
             self._num_edges = mv["num_edges"]
             self._D = mv["D"]
+            # `edges` was not always persisted; older pickles only stored D.
+            if "edges" in mv:
+                self._edges = mv["edges"]
             self._lambda_network_lasso = mv["lambda_network_lasso"]
         # has_group_lasso was added later; default to False for older pickles.
         self._has_group_lasso = mv.get("has_group_lasso", False)

--- a/gamdist/gamdist.py
+++ b/gamdist/gamdist.py
@@ -673,6 +673,15 @@ class GAM:
 
         if len(X) != len(y):
             raise ValueError('Inconsistent number of observations in X and y.')
+        if weights is not None and len(weights) != len(y):
+            raise ValueError(
+                f'weights has length {len(weights)} but y has length {len(y)}.'
+            )
+        if covariate_class_sizes is not None and len(covariate_class_sizes) != len(y):
+            raise ValueError(
+                f'covariate_class_sizes has length {len(covariate_class_sizes)} '
+                f'but y has length {len(y)}.'
+            )
 
         self._rho = 0.1
         eps_abs = 1e-3

--- a/gamdist/gamdist.py
+++ b/gamdist/gamdist.py
@@ -56,37 +56,9 @@ Link = Literal[
 ]
 FeatureType = Literal["categorical", "linear", "spline"]
 
-# To do:
-# - Hierarchical models
-# - Piecewise constant fits, total variation regularization
-# - Monotone constraint
-# - Implement Multinomial, Proportional Hazards
-# - Implement outlier detection
-# - Confidence intervals on mu, predictions (probably need to use Bootstrap but can
-#   do so intelligently)
-# - Confidence intervals on model parameters, p-values
-# - Group lasso penalty for linear and spline features (l2 norm on
-#   f_j(x_j; p_j); categorical is done -- see regularization={"group_lasso": ...})
-# - Group lasso variant with l_\infty norm on f_j(x_j; p_j)
-# - Interactions
-# - Runtime optimization (Cython)
-#
-# Done:
-# - Implement Gaussian, Binomial, Poisson, Gamma, Inv Gaussian,
-# - Plot splines
-# - Deviance (on training set and test set), AIC, AICc, BIC, R^2,
-#   Dispersion, GCV, UBRE
-# - Response, Pearson, deviance, Anscombe residuals; residual-vs-fitted,
-#   residual-vs-predictor, and QQ plots
-# - Write documentation
-# - Check implementation of Gamma dispersion
-# - Implement probit, complementary log-log links.
-# - Implement Binomial models for covariate classes
-# - Constrain spline to have mean prediction 0 over the data
-# - Save and load properly
-# - Implement overdispersion for Binomial family
-# - Implement overdispersion for Poisson family
-# - Fit in parallel (n_jobs= argument on fit(), ThreadPoolExecutor)
+# Open work and historical "done" list now live in the GitHub issue
+# tracker and changelog.txt respectively; see
+# https://github.com/rwilson4/gamdist/issues for the current roadmap.
 
 FAMILIES = ['normal',
             'binomial',

--- a/gamdist/linear_feature.py
+++ b/gamdist/linear_feature.py
@@ -54,11 +54,13 @@ class _LinearFeature(_Feature):
         transform : callable
             Transformation applied to the data (e.g. ``np.log1p``).
         regularization : dict
-            Description of regularization terms. Two kinds of
-            regularization are supported: ``l1`` and ``l2``. Each entry's
-            value is a dict containing a numeric ``coef``. The top-level
+            Description of regularization terms. Currently only ``l2``
+            (ridge) is supported on linear features; the entry's value
+            is a dict containing a numeric ``coef``. The top-level
             ``prior`` key (if present) provides a scalar prior estimate
-            for the slope.
+            for the slope. ``l1`` is not yet implemented for this
+            feature type — see issue #53; for L1 today, use a
+            categorical feature.
         load_from_file : str
             If provided, restore parameters from this pickle path. All
             other parameters are ignored when loading.
@@ -92,11 +94,11 @@ class _LinearFeature(_Feature):
 
         if regularization is not None:
             if "l1" in regularization:
-                self._has_l1 = True
-                if "coef" in regularization["l1"]:
-                    self._coef1 = float(regularization["l1"]["coef"])
-                else:
-                    raise ValueError("No coefficient specified for l1 regularization term.")
+                raise ValueError(
+                    "L1 regularization on linear features is not implemented "
+                    "(see issue #53). Use a categorical feature for L1 today, "
+                    "or restrict this feature's regularization to 'l2'."
+                )
 
             if "l2" in regularization:
                 self._has_l2 = True

--- a/gamdist/proximal_operators.py
+++ b/gamdist/proximal_operators.py
@@ -55,7 +55,8 @@ def _prox_normal(
     inv_link: InvLink | None = None,
     p: Any = None,
 ) -> FloatArray:
-    assert inv_link is not None
+    if inv_link is None:
+        raise ValueError("inv_link is required.")
 
     if w is None:
 
@@ -144,7 +145,8 @@ def _prox_binomial(
     inv_link: InvLink | None = None,
     p: Any = None,
 ) -> FloatArray:
-    assert inv_link is not None
+    if inv_link is None:
+        raise ValueError("inv_link is required.")
 
     if w is None:
 
@@ -229,7 +231,8 @@ def _prox_poisson(
     inv_link: InvLink | None = None,
     p: Any = None,
 ) -> FloatArray:
-    assert inv_link is not None
+    if inv_link is None:
+        raise ValueError("inv_link is required.")
 
     if w is None:
 
@@ -277,7 +280,8 @@ def _prox_gamma(
     inv_link: InvLink | None = None,
     p: Any = None,
 ) -> FloatArray:
-    assert inv_link is not None
+    if inv_link is None:
+        raise ValueError("inv_link is required.")
 
     if w is None:
 
@@ -354,7 +358,8 @@ def _prox_inv_gaussian(
     inv_link: InvLink | None = None,
     p: Any = None,
 ) -> FloatArray:
-    assert inv_link is not None
+    if inv_link is None:
+        raise ValueError("inv_link is required.")
 
     if w is None:
 

--- a/gamdist/proximal_operators.py
+++ b/gamdist/proximal_operators.py
@@ -308,29 +308,42 @@ def _prox_inv_gaussian_reciprocal_squared_scalar(xx: Sequence[float]) -> float:
     y = xx[2]
     w: float | None = xx[3] if len(xx) >= 4 else None
 
+    w_eff = 1.0 if w is None else float(w)
+
+    def obj(z: float) -> float:
+        eta = z * z
+        return 0.5 * w_eff * y * eta - w_eff * z + 0.5 * mu * (eta - v) * (eta - v)
+
     tol = 1e-3
     max_its = 100
 
     z = 1.0
-    if w is None:
-        w_y_minus_mu_v = 0.5 * y - mu * v
-    else:
-        w_y_minus_mu_v = 0.5 * w * y - mu * v
+    w_y_minus_mu_v = 0.5 * w_eff * y - mu * v
 
     for _ in range(max_its):
-        if w is None:
-            num = mu * z * z * z + w_y_minus_mu_v * z - 0.5
-            denom = 3 * mu * z * z + w_y_minus_mu_v
-        else:
-            num = mu * z * z * z + w_y_minus_mu_v * z - 0.5 * w
-            denom = 3 * mu * z * z + w_y_minus_mu_v
+        num = mu * z * z * z + w_y_minus_mu_v * z - 0.5 * w_eff
+        denom = 3 * mu * z * z + w_y_minus_mu_v
 
         dz = num / denom
-        z -= dz
         if abs(dz) < tol:
             return z * z
+        # Damped Newton: backtrack until the objective decreases. The prox is
+        # convex in eta = z^2 but not in z, so the Newton step in z is not
+        # always a descent direction; if backtracking can't find one we fall
+        # through to the bracketed minimization below.
+        f_curr = obj(z)
+        step = 1.0
+        z_new = z - dz
+        while obj(z_new) >= f_curr and step > 1e-12:
+            step *= 0.5
+            z_new = z - step * dz
+        z = z_new
 
-    raise ValueError("Dual variable update failed to converge.")
+    # Newton failed to converge in max_its; fall back to a bracketed 1-D
+    # minimization, matching the pattern used by the binomial / poisson
+    # canonical-link solvers.
+    z_opt = float(minimize_scalar(obj).x)
+    return z_opt * z_opt
 
 
 def _prox_inv_gaussian_reciprocal_squared(

--- a/tests/test_gam_api.py
+++ b/tests/test_gam_api.py
@@ -122,6 +122,26 @@ def test_inconsistent_X_y_lengths_raises() -> None:
         mdl.fit(X, y)
 
 
+def test_fit_weights_wrong_length_raises() -> None:
+    mdl = GAM(family="normal")
+    mdl.add_feature(name="x", type="linear")
+    X = pd.DataFrame({"x": np.arange(10.0)})
+    y = np.arange(10.0)
+    weights = np.ones(5)
+    with pytest.raises(ValueError, match="weights has length"):
+        mdl.fit(X, y, weights=weights)
+
+
+def test_fit_covariate_class_sizes_wrong_length_raises() -> None:
+    mdl = GAM(family="binomial")
+    mdl.add_feature(name="x", type="linear")
+    X = pd.DataFrame({"x": np.arange(10.0)})
+    y = np.arange(10.0)
+    ccs = np.full(7, 10.0)
+    with pytest.raises(ValueError, match="covariate_class_sizes has length"):
+        mdl.fit(X, y, covariate_class_sizes=ccs)
+
+
 def test_summary_prints_features() -> None:
     rng = np.random.default_rng(0)
     n = 100

--- a/tests/test_linear_feature.py
+++ b/tests/test_linear_feature.py
@@ -88,3 +88,8 @@ def test_dof_and_num_params() -> None:
     feat.initialize(np.array([0.0, 1.0]))
     assert feat.num_params() == 1
     assert feat.dof() == 1.0
+
+
+def test_l1_regularization_rejected() -> None:
+    with pytest.raises(ValueError, match="L1 regularization on linear features"):
+        _LinearFeature(name="x", regularization={"l1": {"coef": 1.0}})

--- a/tests/test_persistence.py
+++ b/tests/test_persistence.py
@@ -41,3 +41,34 @@ def test_gam_save_load_round_trip(tmp_path: Path) -> None:
         np.testing.assert_allclose(yhat_after, yhat_before, rtol=1e-12, atol=1e-12)
     finally:
         os.chdir(cwd)
+
+
+def test_network_lasso_edges_persisted(tmp_path: Path) -> None:
+    rng = np.random.default_rng(0)
+    regions = [f"r{i:02d}" for i in range(6)]
+    edges = pd.DataFrame(
+        {"country1": regions[:-1], "country2": regions[1:], "weight": 1.0}
+    )
+    n = 200
+    X = pd.DataFrame({"r": rng.choice(regions, size=n)})
+    y = rng.normal(size=n)
+
+    cwd = os.getcwd()
+    os.chdir(tmp_path)
+    try:
+        mdl = GAM(family="normal", name="net_round_trip")
+        mdl.add_feature(
+            name="r",
+            type="categorical",
+            regularization={"network_lasso": {"coef": 0.5, "edges": edges}},
+        )
+        mdl.fit(X, y, max_its=20, save_flag=True)
+
+        restored = GAM(load_from_file="net_round_trip_model.pckl")
+        restored_feature = restored._features["r"]
+        pd.testing.assert_frame_equal(
+            restored_feature._edges.reset_index(drop=True),  # type: ignore[attr-defined]
+            edges.reset_index(drop=True),
+        )
+    finally:
+        os.chdir(cwd)

--- a/tests/test_persistence.py
+++ b/tests/test_persistence.py
@@ -47,7 +47,7 @@ def test_network_lasso_edges_persisted(tmp_path: Path) -> None:
     rng = np.random.default_rng(0)
     regions = [f"r{i:02d}" for i in range(6)]
     edges = pd.DataFrame(
-        {"country1": regions[:-1], "country2": regions[1:], "weight": 1.0}
+        {"node1": regions[:-1], "node2": regions[1:], "weight": 1.0}
     )
     n = 200
     X = pd.DataFrame({"r": rng.choice(regions, size=n)})

--- a/tests/test_proximal_non_canonical.py
+++ b/tests/test_proximal_non_canonical.py
@@ -125,6 +125,46 @@ def test_prox_inv_gaussian_reciprocal_squared_with_weights() -> None:
     assert out.shape == v.shape
 
 
+def test_prox_inv_gaussian_reciprocal_squared_robust_across_grid() -> None:
+    """Damped Newton + minimize_scalar fallback should never raise on a
+    representative input grid; the previous undamped Newton could crash with
+    'Dual variable update failed to converge.' on harder inputs."""
+    grid_v = [0.01, 0.1, 1.0, 10.0, 100.0]
+    grid_mu = [0.1, 1.0, 10.0]
+    grid_y = [0.01, 0.1, 1.0, 10.0]
+    for v in grid_v:
+        for mu in grid_mu:
+            for y in grid_y:
+                z2 = po._prox_inv_gaussian_reciprocal_squared_scalar([v, mu, y])
+                assert np.isfinite(z2)
+                assert z2 > 0.0
+
+
+def test_prox_inv_gaussian_reciprocal_squared_matches_eta_minimization() -> None:
+    """The prox is convex in eta = z^2; verify the z-space solver returns the
+    same eta as a direct convex minimization in eta."""
+    from scipy.optimize import minimize_scalar
+
+    cases = [
+        (0.5, 1.0, 1.0, None),
+        (1.0, 2.0, 0.5, None),
+        (2.0, 1.0, 0.1, 1.5),
+        (0.1, 5.0, 2.0, None),
+    ]
+    for v, mu, y, w in cases:
+        w_eff = 1.0 if w is None else w
+        # Convex-in-eta objective.
+        def obj_eta(eta: float, _v: float = v, _mu: float = mu, _y: float = y, _w: float = w_eff) -> float:
+            if eta <= 0.0:
+                return float("inf")
+            return 0.5 * _w * _y * eta - _w * np.sqrt(eta) + 0.5 * _mu * (eta - _v) * (eta - _v)
+
+        eta_ref = float(minimize_scalar(obj_eta, bounds=(1e-12, 1e6), method="bounded").x)
+        xx = [v, mu, y] if w is None else [v, mu, y, w]
+        eta_solver = po._prox_inv_gaussian_reciprocal_squared_scalar(xx)
+        np.testing.assert_allclose(eta_solver, eta_ref, rtol=1e-3, atol=1e-3)
+
+
 @pytest.mark.parametrize(
     "fn",
     [

--- a/tests/test_proximal_non_canonical.py
+++ b/tests/test_proximal_non_canonical.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import numpy as np
+import pytest
 
 from gamdist import proximal_operators as po
 
@@ -122,3 +123,20 @@ def test_prox_inv_gaussian_reciprocal_squared_with_weights() -> None:
     w = np.array([1.0, 2.0])
     out = po._prox_inv_gaussian_reciprocal_squared(v, mu=1.0, y=y, w=w)
     assert out.shape == v.shape
+
+
+@pytest.mark.parametrize(
+    "fn",
+    [
+        po._prox_normal,
+        po._prox_binomial,
+        po._prox_poisson,
+        po._prox_gamma,
+        po._prox_inv_gaussian,
+    ],
+)
+def test_non_canonical_prox_raises_when_inv_link_missing(fn) -> None:  # type: ignore[no-untyped-def]
+    v = np.array([0.5, 1.0])
+    y = np.array([1.0, 2.0])
+    with pytest.raises(ValueError, match="inv_link"):
+        fn(v, mu=1.0, y=y)


### PR DESCRIPTION
## Summary

Six bug fixes from the audit pass following PR #38, plus a small chore. All six close tracked issues. No public-API surface change beyond the network_lasso edge-column rename (#37, clean break — see issue notes).

| Commit | Issue | What |
|---|---|---|
| `bcebc61` | #41 | `assert inv_link is not None` → `raise ValueError` in five prox operators (broken under `python -O`) |
| `582aeea` | #40 | `fit()` validates `weights` and `covariate_class_sizes` lengths immediately instead of failing later as a broadcasting error |
| `7085267` | #43 | `network_lasso` `edges` DataFrame now persisted across `save_flag` / `load_from_file` |
| `574d15d` | #37 | Rename `network_lasso` edge columns `country1` / `country2` → `node1` / `node2` |
| `2547915` | #42 | Damped Newton + `minimize_scalar` fallback for inv_gaussian + reciprocal_squared prox (matches the binomial pattern; fixes "Dual variable update failed to converge" hard crash) |
| `6260e0d` | #20 | `_LinearFeature` rejects `regularization={"l1": ...}` with a clear error pointing at categorical-feature L1 and #53 (option B; option A tracked as #53) |
| `b5ad555` | — | Replace gamdist.py to-do/done header with a one-line pointer to the issue tracker (now redundant with GitHub issues + changelog) |

## Follow-up enhancements that came out of this work

- **#52** — reformulate inv_gaussian + reciprocal_squared prox in eta = z² space (drop the damping + fallback added in #42 once we iterate in the natural convex coordinate)
- **#53** — implement L1 properly for `_LinearFeature` (lift the option-B rejection landed here)

## Test plan

- [x] `uv run pytest -q` — 155 passing locally (up from 144 at the merge of #38; +11 new tests across these fixes)
- [x] `uv run ruff check gamdist tests` — clean
- [x] `uv run mypy gamdist` — clean
- [x] Specific new coverage:
  - parametrized assertion-replacement test across all 5 prox functions (#41)
  - bad-length `weights` and `covariate_class_sizes` raise paths (#40)
  - network_lasso `edges` save/load round-trip (#43)
  - `_LinearFeature` rejects L1 with the expected error message (#20)
  - inv_gaussian prox grid sweep + correctness check vs convex-in-eta minimization (#42)

## Notes

- Each commit has its own `changelog.txt` entry; the PR doesn't introduce any extra changelog notes beyond those.
- The `_has_l1` / `_coef1` / `_lambda1` plumbing in `_LinearFeature` is left in place for older-pickle compatibility; #53 will revive it when implementing real L1.

https://claude.ai/code/session_01SaogsGNzg3uciuLKydPceH

---
_Generated by [Claude Code](https://claude.ai/code/session_01SaogsGNzg3uciuLKydPceH)_