### PR TITLE
feat: group lasso regularization for linear and spline features

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,26 @@
+2026-04-26 : Group lasso for linear and spline features
+- _LinearFeature and _SplineFeature now accept
+      regularization={"group_lasso": {"coef": lambda}}
+  matching the categorical-feature pattern added 2026-04-25.
+- Linear: penalty is lambda * ||f_j||_2 = lambda * |m| * sqrt(xtx),
+  which reduces to a 1-D soft-threshold on the slope. Implemented
+  closed-form inside _LinearFeature.optimize alongside the existing
+  ridge solve; no cvxpy dependency added on this path.
+- Spline: penalty is lambda * ||N theta||_2. Group lasso is non-
+  smooth at the origin and breaks the Cholesky-based fast path, so
+  _SplineFeature.optimize routes through cvxpy (CLARABEL) when the
+  regularizer is active and keeps the existing closed-form path
+  otherwise. _SplineFeature.__init__ gains a `regularization` kwarg
+  threaded through GAM.add_feature.
+- Save / load plumbing parallels the categorical implementation;
+  older pickles continue to load (has_group_lasso defaults to False).
+- New tests in tests/test_linear_group_lasso.py and
+  tests/test_spline_group_lasso.py mirror the categorical
+  group-lasso suite: smoothing scaling, soft-threshold closed form,
+  zero-coef matches unpenalized, large-coef zeros the contribution,
+  save/load round-trip, and an end-to-end GAM test where the noise
+  feature shrinks heavily relative to the signal feature. Closes #44.
+
 2026-04-26 : Adopt ruff format
 - Wire `ruff format` in as the project's formatter. `[tool.ruff]`
   line-length drops from 100 to 88 (ruff format / black default) and

--- a/gamdist/gamdist.py
+++ b/gamdist/gamdist.py
@@ -543,10 +543,11 @@ class GAM:
         regularization : dictionary or None
              Dictionary specifying the regularization applied to this feature.
              Different types of features support different types of regularization.
-             Splines implicitly only support regularization of the wiggliness
-             via a C2 smoothness penalty. That is controlled via the rel_dof.
-             Other features have more diverse options described in their own
-             documentation.
+             Splines always include a C2 smoothness penalty controlled via
+             ``rel_dof``; ``regularization={"group_lasso": {"coef": λ}}``
+             additionally shrinks the entire spline contribution and can
+             zero it out. Other features have more diverse options
+             described in their own documentation.
 
         Returns
         -------
@@ -559,7 +560,12 @@ class GAM:
         elif type == "linear":
             f = _LinearFeature(name, transform, regularization=regularization)
         elif type == "spline":
-            f = _SplineFeature(name, transform, rel_dof if rel_dof is not None else 4.0)
+            f = _SplineFeature(
+                name,
+                transform,
+                rel_dof if rel_dof is not None else 4.0,
+                regularization=regularization,
+            )
         else:
             raise ValueError(f"Features of type {type} not supported.")
 

--- a/gamdist/linear_feature.py
+++ b/gamdist/linear_feature.py
@@ -22,6 +22,7 @@
 
 from __future__ import annotations
 
+import math
 import pickle
 from collections.abc import Callable
 from typing import Any
@@ -54,12 +55,14 @@ class _LinearFeature(_Feature):
         transform : callable
             Transformation applied to the data (e.g. ``np.log1p``).
         regularization : dict
-            Description of regularization terms. Currently only ``l2``
-            (ridge) is supported on linear features; the entry's value
-            is a dict containing a numeric ``coef``. The top-level
-            ``prior`` key (if present) provides a scalar prior estimate
-            for the slope. ``l1`` is not yet implemented for this
-            feature type — see issue #53; for L1 today, use a
+            Description of regularization terms. ``l2`` (ridge) takes
+            ``{"coef": λ}`` and adds ``λ · m²`` to the objective.
+            ``group_lasso`` takes ``{"coef": λ}`` and adds
+            ``λ · ‖f_j‖₂ = λ · |m| · √(xᵀx)`` to the objective, which
+            zeros out the entire feature once ``λ`` is large enough.
+            The top-level ``prior`` key (if present) provides a scalar
+            prior estimate for the slope. ``l1`` is not yet implemented
+            for this feature type — see issue #53; for L1 today, use a
             categorical feature.
         load_from_file : str
             If provided, restore parameters from this pickle path. All
@@ -85,11 +88,14 @@ class _LinearFeature(_Feature):
 
         self._has_l1 = False
         self._has_l2 = False
+        self._has_group_lasso = False
         self._has_prior = False
         self._coef1: float = 0.0
         self._coef2: float = 0.0
         self._lambda1: float = 0.0
         self._lambda2: float = 0.0
+        self._coef_group_lasso: float = 0.0
+        self._lambda_group_lasso: float = 0.0
         self._prior: float = 0.0
 
         if regularization is not None:
@@ -107,6 +113,17 @@ class _LinearFeature(_Feature):
                 else:
                     raise ValueError(
                         "No coefficient specified for l2 regularization term."
+                    )
+
+            if "group_lasso" in regularization:
+                self._has_group_lasso = True
+                if "coef" in regularization["group_lasso"]:
+                    self._coef_group_lasso = float(
+                        regularization["group_lasso"]["coef"]
+                    )
+                else:
+                    raise ValueError(
+                        "No coefficient specified for group_lasso regularization term."
                     )
 
             if self._has_l1 or self._has_l2:
@@ -159,6 +176,8 @@ class _LinearFeature(_Feature):
             self._lambda1 = self._coef1 * smoothing
         if self._has_l2:
             self._lambda2 = self._coef2 * smoothing
+        if self._has_group_lasso:
+            self._lambda_group_lasso = self._coef_group_lasso * smoothing
 
         self._verbose = verbose
         if save_flag:
@@ -179,6 +198,7 @@ class _LinearFeature(_Feature):
             "has_transform": self._has_transform,
             "has_l1": self._has_l1,
             "has_l2": self._has_l2,
+            "has_group_lasso": self._has_group_lasso,
             "has_prior": self._has_prior,
             "verbose": self._verbose,
             "name": self._name,
@@ -197,6 +217,9 @@ class _LinearFeature(_Feature):
         if self._has_l2:
             mv["coef2"] = self._coef2
             mv["lambda2"] = self._lambda2
+        if self._has_group_lasso:
+            mv["coef_group_lasso"] = self._coef_group_lasso
+            mv["lambda_group_lasso"] = self._lambda_group_lasso
         if self._has_prior:
             mv["prior"] = self._prior
 
@@ -222,6 +245,14 @@ class _LinearFeature(_Feature):
         if self._has_l2:
             self._coef2 = mv["coef2"]
             self._lambda2 = mv["lambda2"]
+        # has_group_lasso added later; default to False for older pickles.
+        self._has_group_lasso = mv.get("has_group_lasso", False)
+        if self._has_group_lasso:
+            self._coef_group_lasso = mv["coef_group_lasso"]
+            self._lambda_group_lasso = mv["lambda_group_lasso"]
+        else:
+            self._coef_group_lasso = 0.0
+            self._lambda_group_lasso = 0.0
         self._has_prior = mv["has_prior"]
         if self._has_prior:
             self._prior = mv["prior"]
@@ -258,7 +289,22 @@ class _LinearFeature(_Feature):
         else:
             denom = self._xtx
 
-        self._m = float(self._x.dot(y) / denom)
+        b = float(self._x.dot(y))
+
+        if self._has_group_lasso:
+            # Group lasso on the per-feature contribution f_j = m * x_centered.
+            # ||f_j||_2 = |m| * sqrt(xtx), so the penalty contributes a
+            # 1-D soft-threshold on `b` with threshold lambda_gl/rho * sqrt(xtx).
+            threshold = self._lambda_group_lasso * math.sqrt(self._xtx) / rho
+            if b > threshold:
+                self._m = (b - threshold) / denom
+            elif b < -threshold:
+                self._m = (b + threshold) / denom
+            else:
+                self._m = 0.0
+        else:
+            self._m = b / denom
+
         self._b = -self._m * self._xmean
 
         if self._save_self:

--- a/gamdist/spline_feature.py
+++ b/gamdist/spline_feature.py
@@ -25,9 +25,11 @@ from __future__ import annotations
 import math
 import os
 import pickle
+import warnings
 from collections.abc import Callable
 from typing import Any
 
+import cvxpy as cvx
 import numpy as np
 import numpy.typing as npt
 import scipy.linalg as la
@@ -183,8 +185,29 @@ class _SplineFeature(_Feature):
         name: str | None = None,
         transform: Transform | None = None,
         rel_dof: float = 4.0,
+        regularization: dict[str, Any] | None = None,
         load_from_file: str | None = None,
     ) -> None:
+        """Initialize feature model (independent of data).
+
+        Parameters
+        ----------
+        name : str
+            Name for feature, used to make plots.
+        transform : callable
+            Transformation applied to the data (e.g. ``np.log1p``).
+        rel_dof : float
+            Relative degrees of freedom for the curvature smoother.
+        regularization : dict
+            Optional extra regularization beyond the built-in curvature
+            penalty. Currently only ``group_lasso`` is supported, taking
+            ``{"coef": λ}``: it adds ``λ · ‖N θ‖₂`` to the objective,
+            zeroing out the entire spline contribution once λ is large
+            enough.
+        load_from_file : str
+            If provided, restore parameters from this pickle path. All
+            other parameters are ignored when loading.
+        """
         self.__type__ = "spline"
         if load_from_file is not None:
             self._load(load_from_file)
@@ -204,6 +227,19 @@ class _SplineFeature(_Feature):
             self._has_transform = False
 
         self._rel_dof = float(rel_dof)
+
+        self._has_group_lasso = False
+        self._coef_group_lasso: float = 0.0
+        self._lambda_group_lasso: float = 0.0
+        self._solver = "CLARABEL"
+        if regularization is not None and "group_lasso" in regularization:
+            self._has_group_lasso = True
+            if "coef" in regularization["group_lasso"]:
+                self._coef_group_lasso = float(regularization["group_lasso"]["coef"])
+            else:
+                raise ValueError(
+                    "No coefficient specified for group_lasso regularization term."
+                )
 
     def initialize(
         self,
@@ -251,6 +287,9 @@ class _SplineFeature(_Feature):
             A = self._NtN + self._smoothing * self._lmbda * self._Omega
             self._dof = float(_solve_pos(A, self._NtN).trace())
 
+        if self._has_group_lasso:
+            self._lambda_group_lasso = self._coef_group_lasso * smoothing
+
         if save_flag:
             self._save_self = True
             if save_prefix is None:
@@ -283,9 +322,14 @@ class _SplineFeature(_Feature):
             "cho_factor": self._cho_factor,
             "dof": self._dof,
             "save_self": self._save_self,
+            "has_group_lasso": self._has_group_lasso,
+            "solver": self._solver,
         }
         if self._has_transform:
             mv["transform"] = self._transform
+        if self._has_group_lasso:
+            mv["coef_group_lasso"] = self._coef_group_lasso
+            mv["lambda_group_lasso"] = self._lambda_group_lasso
 
         with open(self._filename, "wb") as f:
             pickle.dump(mv, f)
@@ -318,6 +362,15 @@ class _SplineFeature(_Feature):
         self._c = np.zeros(len(self._xi))
         self._w = np.zeros(len(self._xi))
         self._constant = 0.0
+        # has_group_lasso / solver added later; default for older pickles.
+        self._has_group_lasso = mv.get("has_group_lasso", False)
+        self._solver = mv.get("solver", "CLARABEL")
+        if self._has_group_lasso:
+            self._coef_group_lasso = mv["coef_group_lasso"]
+            self._lambda_group_lasso = mv["lambda_group_lasso"]
+        else:
+            self._coef_group_lasso = 0.0
+            self._lambda_group_lasso = 0.0
 
     def optimize(self, fpumz: FloatArray, rho: float) -> FloatArray:
         """Solve the per-feature primal step.
@@ -334,6 +387,18 @@ class _SplineFeature(_Feature):
         fkp1 : (m,) ndarray
             Vector representing this feature's contribution to the response.
         """
+        if self._has_group_lasso:
+            self._theta = self._optimize_cvx(fpumz, rho)
+        else:
+            self._theta = self._optimize_chol(fpumz, rho)
+
+        if self._save_self:
+            self._save()
+
+        return self._N.dot(self._theta)
+
+    def _optimize_chol(self, fpumz: FloatArray, rho: float) -> FloatArray:
+        """Closed-form Cholesky-based primal step (no group lasso)."""
         y = self._N.dot(self._theta) - fpumz
         Nty = self._N.transpose().dot(y)
         if not self._computed_cho_factor:
@@ -347,12 +412,52 @@ class _SplineFeature(_Feature):
 
         assert self._cho_factor is not None
         theta_wc = la.cho_solve(self._cho_factor, Nty, check_finite=False)
-        self._theta = theta_wc - self._constant * self._c.dot(theta_wc) * self._w
+        return theta_wc - self._constant * self._c.dot(theta_wc) * self._w
 
-        if self._save_self:
-            self._save()
+    def _optimize_cvx(self, fpumz: FloatArray, rho: float) -> FloatArray:
+        """Primal step via cvxpy when a group_lasso term is present.
 
-        return self._N.dot(self._theta)
+        Group lasso on the per-feature contribution f_j = N theta penalizes
+        ``λ · ||N θ||₂``, which is non-smooth at zero and breaks the
+        closed-form Cholesky path. The fast path is used whenever group
+        lasso is off, so this branch only runs when needed.
+        """
+        target = self._N.dot(self._theta) - fpumz
+        K = len(self._theta)
+        nu = 2.0 * self._smoothing * self._lmbda / rho
+        gamma = 2.0 * self._lambda_group_lasso / rho
+
+        theta_var = cvx.Variable(K)
+        N_const = cvx.Constant(self._N)
+        Omega_const = cvx.psd_wrap(cvx.Constant(self._Omega))
+        c_vec = np.mean(self._N, axis=0)
+
+        obj = (
+            cvx.sum_squares(N_const @ theta_var - cvx.Constant(target))
+            + nu * cvx.quad_form(theta_var, Omega_const)
+            + gamma * cvx.norm(N_const @ theta_var, 2)
+        )
+        constraints = [cvx.Constant(c_vec) @ theta_var == 0]
+        prob = cvx.Problem(cvx.Minimize(obj), constraints)
+        # cvxpy's "Solution may be inaccurate" UserWarning escapes the
+        # cvxpy.* module filter (cvxpy attributes it to the caller via
+        # stacklevel walking). We accept OPTIMAL_INACCURATE explicitly
+        # below, so suppress the noise here.
+        with warnings.catch_warnings():
+            warnings.filterwarnings(
+                "ignore", message="Solution may be inaccurate", category=UserWarning
+            )
+            prob.solve(verbose=self._verbose, solver=self._solver)
+
+        if prob.status not in (cvx.OPTIMAL, cvx.OPTIMAL_INACCURATE):
+            raise RuntimeError(
+                f"Spline feature {self._name!r} failed to converge "
+                f"(status={prob.status!r})."
+            )
+        value = theta_var.value
+        if value is None:
+            raise RuntimeError(f"Spline feature {self._name!r} produced no solution.")
+        return np.asarray(value, dtype=float).ravel()
 
     def compute_dual_tol(self, y: FloatArray) -> float:
         """Compute this feature's contribution to the dual residual tolerance."""

--- a/tests/test_linear_group_lasso.py
+++ b/tests/test_linear_group_lasso.py
@@ -1,0 +1,151 @@
+"""Tests for the group_lasso regularization on _LinearFeature.
+
+For a linear feature the per-feature contribution vector is
+``f_j = m * (x - mean(x))``. ``||f_j||_2 = |m| * sqrt(xtx)``, so the
+group-lasso penalty acts as a 1-D soft-threshold on the slope and can
+zero it out entirely once λ is large enough.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from gamdist import GAM
+from gamdist.linear_feature import _LinearFeature
+
+
+def test_group_lasso_no_coef_raises() -> None:
+    with pytest.raises(ValueError, match="No coefficient specified for group_lasso"):
+        _LinearFeature(name="x", regularization={"group_lasso": {}})
+
+
+def test_group_lasso_smoothing_scales_lambda() -> None:
+    feat = _LinearFeature(name="x", regularization={"group_lasso": {"coef": 0.4}})
+    feat.initialize(np.array([0.0, 1.0, 2.0, 3.0]), smoothing=2.5)
+    assert feat._has_group_lasso
+    assert feat._lambda_group_lasso == pytest.approx(1.0)
+
+
+def test_group_lasso_lambda_zero_matches_unpenalized() -> None:
+    rng = np.random.default_rng(0)
+    n = 200
+    x = rng.normal(size=n)
+    fpumz = rng.normal(size=n)
+
+    plain = _LinearFeature(name="x")
+    plain.initialize(x)
+    plain.optimize(fpumz, rho=1.0)
+
+    zero = _LinearFeature(name="x", regularization={"group_lasso": {"coef": 0.0}})
+    zero.initialize(x)
+    zero.optimize(fpumz, rho=1.0)
+
+    assert zero._m == pytest.approx(plain._m, rel=1e-12, abs=1e-12)
+
+
+def test_group_lasso_huge_lambda_zeros_slope() -> None:
+    rng = np.random.default_rng(0)
+    n = 200
+    x = rng.normal(size=n)
+    fpumz = rng.normal(size=n)
+    feat = _LinearFeature(name="x", regularization={"group_lasso": {"coef": 1e6}})
+    feat.initialize(x)
+    feat.optimize(fpumz, rho=1.0)
+    assert feat._m == 0.0
+
+
+def test_group_lasso_intermediate_lambda_shrinks() -> None:
+    rng = np.random.default_rng(0)
+    n = 200
+    x = rng.normal(size=n)
+    # Strong signal so the unpenalized fit isn't tiny.
+    y = 2.0 * (x - x.mean()) + 0.1 * rng.normal(size=n)
+
+    unpenalized = _LinearFeature(name="x")
+    unpenalized.initialize(x)
+    unpenalized.optimize(-y, rho=1.0)
+
+    moderate = _LinearFeature(name="x", regularization={"group_lasso": {"coef": 5.0}})
+    moderate.initialize(x)
+    moderate.optimize(-y, rho=1.0)
+
+    assert abs(moderate._m) < abs(unpenalized._m)
+
+
+def test_group_lasso_soft_threshold_closed_form() -> None:
+    # Verify the soft-threshold formula directly.
+    rng = np.random.default_rng(7)
+    n = 50
+    x = rng.normal(size=n)
+    fpumz = rng.normal(size=n)
+    rho = 2.0
+    coef = 0.3
+
+    feat = _LinearFeature(name="x", regularization={"group_lasso": {"coef": coef}})
+    feat.initialize(x)
+    feat.optimize(fpumz, rho=rho)
+
+    x_centered = x - x.mean()
+    xtx = float(x_centered.dot(x_centered))
+    # On the first call _m starts at 0, so y = -fpumz.
+    b = float(x_centered.dot(-fpumz))
+    threshold = coef * np.sqrt(xtx) / rho
+    if abs(b) <= threshold:
+        expected = 0.0
+    else:
+        expected = np.sign(b) * (abs(b) - threshold) / xtx
+    assert feat._m == pytest.approx(expected, rel=1e-12, abs=1e-12)
+
+
+def test_group_lasso_save_load_round_trip(tmp_path: Path) -> None:
+    feat = _LinearFeature(name="x", regularization={"group_lasso": {"coef": 0.7}})
+    feat.initialize(
+        np.arange(5.0),
+        smoothing=2.0,
+        save_flag=True,
+        save_prefix=str(tmp_path / "model"),
+    )
+    feat._m = 1.25
+    feat._b = -0.5
+    feat._save()
+
+    restored = _LinearFeature(load_from_file=feat._filename)
+    assert restored._has_group_lasso
+    assert restored._coef_group_lasso == pytest.approx(0.7)
+    assert restored._lambda_group_lasso == pytest.approx(1.4)
+    assert restored._m == pytest.approx(1.25)
+    assert restored._b == pytest.approx(-0.5)
+
+
+def test_group_lasso_within_gam_drops_noise_feature() -> None:
+    # Two linear features. "signal" actually drives y; "noise" does not.
+    # With a moderate group lasso applied to *both*, noise should shrink
+    # to (near) zero while signal retains meaningful slope.
+    rng = np.random.default_rng(2)
+    n = 400
+    signal = rng.normal(size=n)
+    noise = rng.normal(size=n)
+    y = 1.5 * (signal - signal.mean()) + 0.1 * rng.normal(size=n)
+    X = pd.DataFrame({"signal": signal, "noise": noise})
+
+    mdl = GAM(family="normal")
+    mdl.add_feature(
+        name="signal",
+        type="linear",
+        regularization={"group_lasso": {"coef": 0.3}},
+    )
+    mdl.add_feature(
+        name="noise",
+        type="linear",
+        regularization={"group_lasso": {"coef": 0.3}},
+    )
+    mdl.fit(X, y, max_its=60)
+
+    signal_feat = mdl._features["signal"]
+    noise_feat = mdl._features["noise"]
+    assert abs(signal_feat._m) > 0.5  # type: ignore[attr-defined]
+    assert abs(noise_feat._m) < 0.1 * abs(signal_feat._m)  # type: ignore[attr-defined]

--- a/tests/test_spline_group_lasso.py
+++ b/tests/test_spline_group_lasso.py
@@ -1,0 +1,154 @@
+"""Tests for the group_lasso regularization on _SplineFeature.
+
+For a spline feature the per-feature contribution vector is
+``f_j = N θ``. The group-lasso penalty ``λ · ||N θ||_2`` shrinks the
+entire fitted spline toward zero and can zero it out completely once
+λ is large enough. The closed-form Cholesky path is preserved when
+group lasso is off; this test file targets the cvxpy-based path.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from gamdist import GAM
+from gamdist.spline_feature import _SplineFeature
+
+
+def test_group_lasso_no_coef_raises() -> None:
+    with pytest.raises(ValueError, match="No coefficient specified for group_lasso"):
+        _SplineFeature(name="x", regularization={"group_lasso": {}})
+
+
+def test_group_lasso_smoothing_scales_lambda() -> None:
+    feat = _SplineFeature(name="x", regularization={"group_lasso": {"coef": 0.4}})
+    feat.initialize(np.linspace(0.0, 1.0, 50), smoothing=2.5)
+    assert feat._has_group_lasso
+    assert feat._lambda_group_lasso == pytest.approx(1.0)
+
+
+def test_group_lasso_lambda_zero_matches_unpenalized() -> None:
+    # NtN is heavily rank-deficient (the cubic-regression-spline basis on
+    # finitely many distinct x values has nontrivial nullspace), so the
+    # raw theta vector isn't unique. The fitted contribution N @ theta is.
+    rng = np.random.default_rng(0)
+    n = 200
+    x = rng.uniform(0.0, 1.0, size=n)
+    y = np.sin(2 * np.pi * x)
+    y = y - y.mean()
+
+    plain = _SplineFeature(name="x", rel_dof=6.0)
+    plain.initialize(x)
+    plain.optimize(-y, rho=1.0)
+    plain_pred = plain._N.dot(plain._theta)
+
+    zero = _SplineFeature(
+        name="x", rel_dof=6.0, regularization={"group_lasso": {"coef": 0.0}}
+    )
+    zero.initialize(x)
+    zero.optimize(-y, rho=1.0)
+    zero_pred = zero._N.dot(zero._theta)
+
+    np.testing.assert_allclose(zero_pred, plain_pred, atol=1e-6)
+
+
+def test_group_lasso_huge_lambda_zeros_contribution() -> None:
+    # CLARABEL becomes numerically unstable at very large penalty
+    # multipliers (~1e6 on the SOC coefficient is too aggressive for the
+    # default tolerances), so use a still-large-but-tractable λ that's
+    # well above the soft-threshold boundary for the data scale.
+    rng = np.random.default_rng(0)
+    n = 200
+    x = rng.uniform(0.0, 1.0, size=n)
+    y = np.sin(2 * np.pi * x)
+    y = y - y.mean()
+    feat = _SplineFeature(
+        name="x", rel_dof=6.0, regularization={"group_lasso": {"coef": 1e3}}
+    )
+    feat.initialize(x)
+    feat.optimize(-y, rho=1.0)
+    pred = feat.predict(x)
+    np.testing.assert_allclose(pred, 0.0, atol=1e-4)
+
+
+def test_group_lasso_intermediate_lambda_shrinks() -> None:
+    rng = np.random.default_rng(0)
+    n = 200
+    x = rng.uniform(0.0, 1.0, size=n)
+    y = 3.0 * np.sin(2 * np.pi * x)
+    y = y - y.mean()
+
+    unpenalized = _SplineFeature(name="x", rel_dof=6.0)
+    unpenalized.initialize(x)
+    unpenalized.optimize(-y, rho=1.0)
+
+    moderate = _SplineFeature(
+        name="x", rel_dof=6.0, regularization={"group_lasso": {"coef": 1.0}}
+    )
+    moderate.initialize(x)
+    moderate.optimize(-y, rho=1.0)
+
+    assert np.linalg.norm(moderate.predict(x)) < np.linalg.norm(unpenalized.predict(x))
+
+
+def test_group_lasso_save_load_round_trip(tmp_path: Path) -> None:
+    rng = np.random.default_rng(0)
+    x = rng.uniform(0.0, 1.0, size=50)
+    feat = _SplineFeature(
+        name="x", rel_dof=4.0, regularization={"group_lasso": {"coef": 0.7}}
+    )
+    feat.initialize(
+        x,
+        smoothing=2.0,
+        save_flag=True,
+        save_prefix=str(tmp_path / "model"),
+    )
+    feat._theta = np.linspace(0.0, 1.0, len(feat._theta))
+    feat._save()
+
+    restored = _SplineFeature(load_from_file=feat._filename)
+    assert restored._has_group_lasso
+    assert restored._coef_group_lasso == pytest.approx(0.7)
+    assert restored._lambda_group_lasso == pytest.approx(1.4)
+    np.testing.assert_allclose(restored._theta, feat._theta)
+
+
+def test_group_lasso_within_gam_drops_noise_feature() -> None:
+    # Two spline features. "signal" actually drives y; "noise" does not.
+    # With a moderate group lasso applied to *both*, the noise spline
+    # should shrink heavily while the signal spline retains a real shape.
+    rng = np.random.default_rng(2)
+    n = 400
+    signal = rng.uniform(0.0, 1.0, size=n)
+    noise = rng.uniform(0.0, 1.0, size=n)
+    y = np.sin(2 * np.pi * signal) + 0.1 * rng.normal(size=n)
+    y = y - y.mean()
+    X = pd.DataFrame({"signal": signal, "noise": noise})
+
+    mdl = GAM(family="normal")
+    mdl.add_feature(
+        name="signal",
+        type="spline",
+        rel_dof=6.0,
+        regularization={"group_lasso": {"coef": 0.3}},
+    )
+    mdl.add_feature(
+        name="noise",
+        type="spline",
+        rel_dof=6.0,
+        regularization={"group_lasso": {"coef": 0.3}},
+    )
+    mdl.fit(X, y, max_its=40)
+
+    signal_feat = mdl._features["signal"]
+    noise_feat = mdl._features["noise"]
+    signal_pred = signal_feat.predict(signal)
+    noise_pred = noise_feat.predict(noise)
+    signal_norm = float(np.linalg.norm(signal_pred))
+    noise_norm = float(np.linalg.norm(noise_pred))
+    assert signal_norm > 1.0
+    assert noise_norm < 0.2 * signal_norm


### PR DESCRIPTION
Mirrors the categorical-feature group_lasso added 2026-04-25 to the
remaining feature types so users can drive an entire feature
contribution to zero with a single penalty term.

_LinearFeature gets a closed-form 1-D soft-threshold on the slope
(no cvxpy dependency on this path). _SplineFeature routes through
CLARABEL when the penalty is active, keeping the existing
Cholesky-based fast path when it isn't; __init__ gains a
regularization kwarg threaded through GAM.add_feature. Save/load
preserves the new state and older pickles continue to load.

Closes #44.