### PR TITLE
feat: network ridge regularizer for categorical features

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,8 @@
 A modular toolkit for the GLM/GAM zoo — binary, continuous, or count
 outcomes; continuous, categorical, or spline-transformed features;
 arbitrary regularization (ridge, L1, group lasso, network lasso,
-curvature penalties) attached to whichever terms want it. Every model is
-a single convex optimization problem.
+network ridge, curvature penalties) attached to whichever terms want
+it. Every model is a single convex optimization problem.
 
 The joint Hessian for that problem is intractable to derive and solve as
 a monolith. The ADMM decomposition of [Chu, Keshavarz, Boyd][gamadmm]
@@ -29,8 +29,10 @@ applied inside the per-feature ADMM step:
   ridge (`l2`).
 - **`categorical`** — per-level offset for a categorical feature.
   Supports `l1`, `l2`, group lasso (`group_lasso`) for variable
-  selection, and **network lasso** (`network_lasso`) for clustering
-  connected categories to identical coefficients.
+  selection, **network lasso** (`network_lasso`) for clustering
+  connected categories to identical coefficients, and **network
+  ridge** (`network_ridge`) for smoothly shrinking connected
+  categories toward each other.
 - **`spline`** — cubic regression spline with an integrated curvature
   penalty. Smoothing is set via `rel_dof`, the target effective degrees
   of freedom.
@@ -114,6 +116,12 @@ mdl.add_feature(
 mdl.fit(X, y)
 mdl.summary()
 ```
+
+Swap `network_lasso` for `network_ridge` on the same edges DataFrame
+to get the smooth-shrinkage variant: a quadratic penalty
+`λ · Σ w_ij · (β_i − β_j)²` (= `λ · βᵀ L β` for the graph Laplacian
+`L`) that pulls neighboring coefficients *toward* each other instead
+of clustering them to identical values.
 
 ## Development
 

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,31 @@
+2026-04-26 : Network ridge regularizer for categorical features
+- _CategoricalFeature now accepts
+      regularization={"network_ridge": {"coef": lambda, "edges": edges}}
+  alongside the existing l1/l2/network_lasso/group_lasso options.
+- Penalty is the smooth-shrinkage sibling of network_lasso:
+      lambda * sum_{(i,j) in E} w_ij * (q_i - q_j)^2  =  lambda * q^T L q
+  where L is the (weighted) graph Laplacian of the edges. The penalty
+  is convex quadratic, so it lands as (2*lambda/rho) * L added to the
+  AtA Hessian inside the categorical cvxpy program -- no new cvxpy
+  variables or constraints. Lambda is scaled by the global `smoothing`
+  argument (matching the other categorical penalties).
+- Edges DataFrame uses the same node1 / node2 / weight schema accepted
+  by network_lasso. Categories appearing only in the edge list (not in
+  the training data) are still added to the feature's categories so
+  they get coefficients shrunk toward their neighbors.
+- Persisted across save/load. Older pickles default has_network_ridge
+  to False on load.
+- Tests in tests/test_categorical_network_ridge.py cover: missing-coef
+  / missing-edges error paths, smoothing scaling, Laplacian structure
+  (symmetric, row-sums-zero, PSD), lambda=0 parity with the
+  unpenalized solve, empty edges DataFrame parity with the
+  unpenalized solve, huge-lambda collapsing all coefficients to the
+  zero-sum-constrained constant, intermediate-lambda shrinkage of
+  neighbor differences, save/load round-trip, an end-to-end test
+  where network ridge beats plain L2 on a noisily under-sampled
+  region in a smooth-along-the-chain spatial signal, and a
+  combined-with-L2 sanity check. Closes #36.
+
 2026-04-26 : Group lasso for linear and spline features
 - _LinearFeature and _SplineFeature now accept
       regularization={"group_lasso": {"coef": lambda}}

--- a/gamdist/categorical_feature.py
+++ b/gamdist/categorical_feature.py
@@ -54,8 +54,8 @@ class _CategoricalFeature(_Feature):
             Name for feature, used to make plots.
         regularization : dict
             Description of regularization terms (``l1``, ``l2``,
-            ``group_lasso``, ``network_lasso``). See the package
-            README for details.
+            ``group_lasso``, ``network_lasso``, ``network_ridge``).
+            See the package README for details.
         load_from_file : str
             Pickle path used to restore parameters. If specified,
             other parameters are ignored.
@@ -76,13 +76,16 @@ class _CategoricalFeature(_Feature):
         self._has_l1 = False
         self._has_l2 = False
         self._has_network_lasso = False
+        self._has_network_ridge = False
         self._has_group_lasso = False
         self._has_prior = False
         self._coef1: float | dict[Any, float] = 0.0
         self._coef2: float | dict[Any, float] = 0.0
         self._lambda_network_lasso: float = 0.0
+        self._lambda_network_ridge: float = 0.0
         self._lambda_group_lasso: float = 0.0
         self._num_edges: int = 0
+        self._num_edges_ridge: int = 0
         if regularization is not None:
             if "l1" in regularization:
                 self._has_l1 = True
@@ -124,6 +127,30 @@ class _CategoricalFeature(_Feature):
                 else:
                     raise ValueError(
                         "Edges not specified for Network Lasso regularization term."
+                    )
+
+            if "network_ridge" in regularization:
+                self._has_network_ridge = True
+                if "coef" in regularization["network_ridge"]:
+                    self._lambda_network_ridge = float(
+                        regularization["network_ridge"]["coef"]
+                    )
+                else:
+                    raise ValueError(
+                        "No coefficient specified for Network Ridge regularization term."
+                    )
+
+                if "edges" in regularization["network_ridge"]:
+                    self._edges_ridge = regularization["network_ridge"]["edges"]
+                    self._num_edges_ridge, _ = self._edges_ridge.shape
+                    for _, row in self._edges_ridge.iterrows():
+                        if row["node1"] not in self._categories:
+                            self._categories.append(row["node1"])
+                        if row["node2"] not in self._categories:
+                            self._categories.append(row["node2"])
+                else:
+                    raise ValueError(
+                        "Edges not specified for Network Ridge regularization term."
                     )
 
             if "group_lasso" in regularization:
@@ -178,6 +205,29 @@ class _CategoricalFeature(_Feature):
             self._D = sparse.coo_matrix(D).tocsr()
             self._lambda_network_lasso *= smoothing
 
+        if self._has_network_ridge:
+            # Build the (weighted) graph Laplacian L so the penalty
+            # lambda * sum_{(i,j) in E} w_ij * (q_i - q_j)^2 equals
+            # lambda * q^T L q. Symmetric PSD by construction, so the
+            # Hessian contribution (2 lambda / rho) * L keeps the
+            # subproblem convex.
+            _, em = self._edges_ridge.shape
+            rows: list[int] = []
+            cols: list[int] = []
+            data: list[float] = []
+            for _, row in self._edges_ridge.iterrows():
+                i = self._category_hash[row["node1"]]
+                j = self._category_hash[row["node2"]]
+                w = float(row["weight"]) if em >= 3 else 1.0
+                rows += [i, j, i, j]
+                cols += [i, j, j, i]
+                data += [w, w, -w, -w]
+            self._L = sparse.coo_matrix(
+                (data, (rows, cols)),
+                shape=(self._num_categories, self._num_categories),
+            ).tocsr()
+            self._lambda_network_ridge *= smoothing
+
         if na_signifier is not None and na_signifier in self._categories:
             self._na_index = self._category_hash[na_signifier]
         else:
@@ -223,6 +273,8 @@ class _CategoricalFeature(_Feature):
             print(f"Number of categories: {self._num_categories:d}")
             if self._has_network_lasso:
                 print(f"Number of edges: {self._num_edges:d}")
+            if self._has_network_ridge:
+                print(f"Number of network-ridge edges: {self._num_edges_ridge:d}")
 
         if save_flag:
             self._save_self = True
@@ -265,6 +317,7 @@ class _CategoricalFeature(_Feature):
             "has_l1": self._has_l1,
             "has_l2": self._has_l2,
             "has_network_lasso": self._has_network_lasso,
+            "has_network_ridge": self._has_network_ridge,
             "has_group_lasso": self._has_group_lasso,
             "has_prior": self._has_prior,
             "na_index": self._na_index,
@@ -289,6 +342,11 @@ class _CategoricalFeature(_Feature):
             mv["D"] = self._D
             mv["edges"] = self._edges
             mv["lambda_network_lasso"] = self._lambda_network_lasso
+        if self._has_network_ridge:
+            mv["num_edges_ridge"] = self._num_edges_ridge
+            mv["L"] = self._L
+            mv["edges_ridge"] = self._edges_ridge
+            mv["lambda_network_ridge"] = self._lambda_network_ridge
         if self._has_group_lasso:
             mv["lambda_group_lasso"] = self._lambda_group_lasso
         if self._has_prior:
@@ -323,6 +381,16 @@ class _CategoricalFeature(_Feature):
             if "edges" in mv:
                 self._edges = mv["edges"]
             self._lambda_network_lasso = mv["lambda_network_lasso"]
+        # has_network_ridge was added later; default to False for older pickles.
+        self._has_network_ridge = mv.get("has_network_ridge", False)
+        if self._has_network_ridge:
+            self._num_edges_ridge = mv["num_edges_ridge"]
+            self._L = mv["L"]
+            if "edges_ridge" in mv:
+                self._edges_ridge = mv["edges_ridge"]
+            self._lambda_network_ridge = mv["lambda_network_ridge"]
+        else:
+            self._lambda_network_ridge = 0.0
         # has_group_lasso was added later; default to False for older pickles.
         self._has_group_lasso = mv.get("has_group_lasso", False)
         if self._has_group_lasso:
@@ -366,16 +434,17 @@ class _CategoricalFeature(_Feature):
 
         q = cvx.Variable(self._num_categories)
 
+        ata_matrix: Any = self._AtA
         if self._has_l2:
-            AtA = cvx.Constant(
-                self._AtA
-                + sparse.dia_matrix(
-                    ((2.0 / rho) * self._lambda2, 0),
-                    shape=(self._num_categories, self._num_categories),
-                )
+            ata_matrix = ata_matrix + sparse.dia_matrix(
+                ((2.0 / rho) * self._lambda2, 0),
+                shape=(self._num_categories, self._num_categories),
             )
-        else:
-            AtA = cvx.Constant(self._AtA)
+        if self._has_network_ridge:
+            ata_matrix = (
+                ata_matrix + ((2.0 / rho) * self._lambda_network_ridge) * self._L
+            )
+        AtA = cvx.Constant(ata_matrix)
 
         Atb_const = cvx.Constant(Atb)
 

--- a/tests/test_categorical_network_ridge.py
+++ b/tests/test_categorical_network_ridge.py
@@ -1,0 +1,269 @@
+"""Tests for the network_ridge regularization on _CategoricalFeature.
+
+Network ridge applies a quadratic penalty to the differences between
+coefficients of categories connected by a user-supplied edge list. The
+penalty term is ``lambda * sum_{(i,j) in E} w_ij * (q_i - q_j)^2 =
+lambda * q^T L q`` where ``L`` is the (weighted) graph Laplacian. It is
+the smooth-shrinkage sibling of ``network_lasso``, which clusters
+neighbors to identical coefficients via L1 on the same edge differences.
+"""
+
+from __future__ import annotations
+
+from itertools import pairwise
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from gamdist import GAM
+from gamdist.categorical_feature import _CategoricalFeature
+
+
+def _chain_edges(regions: list[str], weight: float = 1.0) -> pd.DataFrame:
+    return pd.DataFrame(
+        {
+            "node1": regions[:-1],
+            "node2": regions[1:],
+            "weight": [weight] * (len(regions) - 1),
+        }
+    )
+
+
+def test_network_ridge_no_coef_raises() -> None:
+    edges = _chain_edges(["a", "b", "c"])
+    with pytest.raises(ValueError, match="No coefficient specified for Network Ridge"):
+        _CategoricalFeature(
+            name="g", regularization={"network_ridge": {"edges": edges}}
+        )
+
+
+def test_network_ridge_no_edges_raises() -> None:
+    with pytest.raises(ValueError, match="Edges not specified for Network Ridge"):
+        _CategoricalFeature(name="g", regularization={"network_ridge": {"coef": 0.5}})
+
+
+def test_network_ridge_smoothing_scales_lambda() -> None:
+    edges = _chain_edges(["a", "b"])
+    feat = _CategoricalFeature(
+        name="g", regularization={"network_ridge": {"coef": 0.4, "edges": edges}}
+    )
+    feat.initialize(np.array(["a", "b", "a"]), smoothing=2.5)
+    assert feat._has_network_ridge
+    assert feat._lambda_network_ridge == pytest.approx(1.0)
+
+
+def test_network_ridge_laplacian_structure() -> None:
+    # Two-node, single-edge graph: L = [[w, -w], [-w, w]].
+    edges = _chain_edges(["a", "b"], weight=2.0)
+    feat = _CategoricalFeature(
+        name="g", regularization={"network_ridge": {"coef": 1.0, "edges": edges}}
+    )
+    feat.initialize(np.array(["a", "b"]))
+    a = feat._category_hash["a"]
+    b = feat._category_hash["b"]
+    L = feat._L.toarray()
+    assert L[a, a] == pytest.approx(2.0)
+    assert L[b, b] == pytest.approx(2.0)
+    assert L[a, b] == pytest.approx(-2.0)
+    assert L[b, a] == pytest.approx(-2.0)
+    # Symmetric and PSD: row sums to zero, eigenvalues all >= 0.
+    np.testing.assert_allclose(L.sum(axis=1), 0.0)
+    eigvals = np.linalg.eigvalsh(L)
+    assert eigvals.min() >= -1e-12
+
+
+def test_network_ridge_lambda_zero_matches_unpenalized() -> None:
+    rng = np.random.default_rng(0)
+    x = rng.choice(np.array(["a", "b", "c"]), size=200)
+    fpumz = rng.normal(size=200)
+    edges = _chain_edges(["a", "b", "c"])
+
+    plain = _CategoricalFeature(name="g")
+    plain.initialize(x)
+    plain.optimize(fpumz, rho=1.0)
+
+    zero = _CategoricalFeature(
+        name="g", regularization={"network_ridge": {"coef": 0.0, "edges": edges}}
+    )
+    zero.initialize(x)
+    zero.optimize(fpumz, rho=1.0)
+
+    np.testing.assert_allclose(zero.p, plain.p, atol=1e-6)
+
+
+def test_network_ridge_empty_edges_matches_unpenalized() -> None:
+    # Empty edges DataFrame: Laplacian is the zero matrix, so the fit
+    # should match the unregularized solution.
+    rng = np.random.default_rng(1)
+    x = rng.choice(np.array(["a", "b", "c"]), size=200)
+    fpumz = rng.normal(size=200)
+    empty_edges = pd.DataFrame({"node1": [], "node2": [], "weight": []})
+
+    plain = _CategoricalFeature(name="g")
+    plain.initialize(x)
+    plain.optimize(fpumz, rho=1.0)
+
+    empty = _CategoricalFeature(
+        name="g",
+        regularization={"network_ridge": {"coef": 5.0, "edges": empty_edges}},
+    )
+    empty.initialize(x)
+    empty.optimize(fpumz, rho=1.0)
+
+    np.testing.assert_allclose(empty.p, plain.p, atol=1e-6)
+
+
+def test_network_ridge_huge_lambda_collapses_to_constant() -> None:
+    # As lambda -> infinity, neighbor differences go to zero. With a
+    # connected graph and the zero-sum constraint imposed by ccs, every
+    # coefficient must approach 0.
+    rng = np.random.default_rng(2)
+    x = rng.choice(np.array(["a", "b", "c", "d"]), size=300)
+    fpumz = rng.normal(size=300) + 1.0
+    edges = _chain_edges(["a", "b", "c", "d"])
+    feat = _CategoricalFeature(
+        name="g", regularization={"network_ridge": {"coef": 1e6, "edges": edges}}
+    )
+    feat.initialize(x)
+    feat.optimize(fpumz, rho=1.0)
+    np.testing.assert_allclose(feat.p, 0.0, atol=1e-3)
+
+
+def test_network_ridge_intermediate_lambda_shrinks_neighbor_gap() -> None:
+    # On a smooth-along-the-chain signal, network ridge should pull
+    # neighboring coefficients closer together than the unpenalized fit.
+    rng = np.random.default_rng(3)
+    regions = [f"r{i:02d}" for i in range(8)]
+    true_effect = dict(zip(regions, np.linspace(-1.0, 1.0, len(regions)), strict=True))
+    n = 400
+    x = rng.choice(np.array(regions), size=n)
+    fpumz = np.array([true_effect[r] for r in x]) + rng.normal(scale=0.5, size=n)
+    edges = _chain_edges(regions)
+
+    unpenalized = _CategoricalFeature(name="g")
+    unpenalized.initialize(x)
+    unpenalized.optimize(fpumz, rho=1.0)
+
+    moderate = _CategoricalFeature(
+        name="g", regularization={"network_ridge": {"coef": 50.0, "edges": edges}}
+    )
+    moderate.initialize(x)
+    moderate.optimize(fpumz, rho=1.0)
+
+    # Sum of squared neighbor differences should drop substantially.
+    def neighbor_ssq(p: np.ndarray, feat: _CategoricalFeature) -> float:
+        total = 0.0
+        for r1, r2 in pairwise(regions):
+            i = feat._category_hash[r1]
+            j = feat._category_hash[r2]
+            total += float((p[i] - p[j]) ** 2)
+        return total
+
+    assert neighbor_ssq(moderate.p, moderate) < 0.5 * neighbor_ssq(
+        unpenalized.p, unpenalized
+    )
+
+
+def test_network_ridge_save_load_round_trip(tmp_path: Path) -> None:
+    edges = _chain_edges(["a", "b", "c"])
+    feat = _CategoricalFeature(
+        name="g", regularization={"network_ridge": {"coef": 0.7, "edges": edges}}
+    )
+    feat.initialize(
+        np.array(["a", "b", "a", "c"]),
+        smoothing=2.0,
+        save_flag=True,
+        save_prefix=str(tmp_path / "model"),
+    )
+    feat.p = np.array([0.3, -0.1, -0.2])
+    feat._save()
+
+    restored = _CategoricalFeature(load_from_file=feat._filename)
+    assert restored._has_network_ridge
+    assert restored._lambda_network_ridge == pytest.approx(1.4)
+    assert restored._num_edges_ridge == 2
+    np.testing.assert_allclose(restored._L.toarray(), feat._L.toarray())
+    pd.testing.assert_frame_equal(
+        restored._edges_ridge.reset_index(drop=True),
+        edges.reset_index(drop=True),
+    )
+    np.testing.assert_allclose(restored.p, feat.p)
+
+
+def test_network_ridge_beats_plain_l2_on_smooth_spatial_signal() -> None:
+    # Synthetic spatial setup: 12 regions in a chain with a smooth-along-
+    # the-chain true effect. The middle region is undersampled (only a
+    # handful of noisy observations), so plain L2 has almost no signal
+    # for it and shrinks its coefficient toward zero. Network ridge, by
+    # tying the coefficient to its neighbors, should land closer to the
+    # true effect at the under-sampled region.
+    rng = np.random.default_rng(4)
+    regions = [f"r{i:02d}" for i in range(12)]
+    centered = np.linspace(-1.0, 1.0, len(regions))
+    centered = centered - centered.mean()
+    true_effect = dict(zip(regions, centered, strict=True))
+
+    # Pick a region whose true effect is far from zero, so that L2
+    # shrinkage toward 0 noticeably misses while neighbor-borrowing
+    # via the chain stays close to truth.
+    target_region = "r10"
+    n_well_sampled = 200
+    n_target = 3
+    well_sampled_regions = [r for r in regions if r != target_region]
+    x_well = rng.choice(np.array(well_sampled_regions), size=n_well_sampled)
+    x_target = np.array([target_region] * n_target)
+    x_train = np.concatenate([x_well, x_target])
+    y_train = np.array([true_effect[r] for r in x_train]) + rng.normal(
+        scale=0.3, size=len(x_train)
+    )
+
+    X_train = pd.DataFrame({"region": x_train})
+    edges = _chain_edges(regions)
+
+    ridge_mdl = GAM(family="normal")
+    ridge_mdl.add_feature(
+        name="region",
+        type="categorical",
+        regularization={"network_ridge": {"coef": 50.0, "edges": edges}},
+    )
+    ridge_mdl.fit(X_train, y_train, max_its=80)
+
+    l2_mdl = GAM(family="normal")
+    l2_mdl.add_feature(
+        name="region",
+        type="categorical",
+        regularization={"l2": {"coef": 50.0}},
+    )
+    l2_mdl.fit(X_train, y_train, max_its=80)
+
+    target_df = pd.DataFrame({"region": [target_region]})
+    ridge_pred = ridge_mdl.predict(target_df)[0]
+    l2_pred = l2_mdl.predict(target_df)[0]
+    target = true_effect[target_region]
+
+    # Network ridge propagates the effect across the adjacency and
+    # should land closer to the true value than plain L2, which only
+    # has the few noisy direct observations to work with.
+    assert abs(ridge_pred - target) < abs(l2_pred - target)
+
+
+def test_network_ridge_combined_with_l2() -> None:
+    # Both penalties active: still solves and produces finite coefficients.
+    rng = np.random.default_rng(5)
+    x = rng.choice(np.array(["a", "b", "c"]), size=200)
+    fpumz = rng.normal(size=200)
+    edges = _chain_edges(["a", "b", "c"])
+    feat = _CategoricalFeature(
+        name="g",
+        regularization={
+            "l2": {"coef": 0.2},
+            "network_ridge": {"coef": 0.5, "edges": edges},
+        },
+    )
+    feat.initialize(x)
+    feat.optimize(fpumz, rho=1.0)
+    assert np.all(np.isfinite(feat.p))
+    # Zero-sum constraint still respected.
+    assert abs(feat._ccs @ feat.p) < 1e-6


### PR DESCRIPTION
Adds the smooth-shrinkage sibling of network_lasso: a quadratic
penalty lambda * sum_{(i,j) in E} w_ij * (q_i - q_j)^2 = lambda * q^T L q
where L is the (weighted) graph Laplacian. Lands as (2*lambda/rho) * L
added to the AtA Hessian inside the categorical cvxpy program -- no
new variables or constraints. Reuses the same edges DataFrame schema
as network_lasso. Closes #36.