### PR TITLE
feat: quantile (pinball) family for conditional quantile regression

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,41 @@
+2026-04-26 : Quantile (pinball-loss) family for conditional quantile regression
+- GAM now accepts family="quantile" with a required tau parameter in
+  (0, 1). Only link="identity" is supported (the M-estimator framing
+  is convex only at the identity link); other links raise up front.
+  tau=0.5 fits the conditional median; tau in (0, 1) fits an arbitrary
+  conditional quantile.
+- Pinball loss rho_tau(r) = max(tau*r, (tau-1)*r) plugs into the ADMM
+  loop as a new entry in the (family, link) prox dispatch:
+  _prox_quantile_identity in gamdist/proximal_operators.py is the
+  closed-form shifted-soft-threshold
+      x* = v + w*tau/mu        if y > v + w*tau/mu
+      x* = v - w*(1-tau)/mu    if y < v - w*(1-tau)/mu
+      x* = y                   otherwise
+  i.e. the same shape as the L1 prox with asymmetric thresholds.
+  No ADMM-loop changes; per-feature primal steps see only fpumz and
+  rho exactly as before.
+- The training offset (which anchors the model's average prediction,
+  since every feature is mean-zero) is set to np.quantile(y, tau)
+  for the quantile family instead of mean(y). Without this the
+  intercept is locked to the wrong target for tau != 0.5 and ADMM
+  cannot reach the correct fit.
+- _deviance_from_mu treats 2 * sum(rho_tau(y - mu)) as the family's
+  "deviance" (the M-estimator analogue of -2 * log-likelihood used
+  by the convergence trace and AIC/BIC summaries); dispersion() is
+  fixed at 1.0. quantile is added to FAMILIES_WITH_KNOWN_DISPERSIONS
+  so AIC/BIC don't add a phantom DOF for an estimated dispersion.
+- tau is persisted in save/load; older pickles default tau to None.
+- Tests in tests/test_proximal_operators.py cover the prox vs.
+  scipy.optimize.minimize_scalar on the same scalar objective across
+  tau values, the shifted-soft-threshold thresholds, the weighted
+  variant, and the median collapse to the symmetric L1 prox.
+  tests/test_quantile.py adds an end-to-end recovery test on
+  heteroskedastic data y = x + (1+x)*N(0,1) for tau in {0.1, 0.5, 0.9}
+  (true conditional quantile is linear in x), an empirical-coverage
+  check on a held-out sample for tau in {0.2, 0.8}, API validation
+  (missing / out-of-range tau, non-identity link), the deviance =
+  2 * sum(pinball) identity, and a save/load round-trip. Closes #22.
+
 2026-04-26 : Network ridge regularizer for categorical features
 - _CategoricalFeature now accepts
       regularization={"network_ridge": {"coef": lambda, "edges": edges}}

--- a/gamdist/gamdist.py
+++ b/gamdist/gamdist.py
@@ -45,7 +45,13 @@ from .spline_feature import _SplineFeature
 FloatArray = npt.NDArray[np.float64]
 
 Family = Literal[
-    "normal", "binomial", "poisson", "gamma", "exponential", "inverse_gaussian"
+    "normal",
+    "binomial",
+    "poisson",
+    "gamma",
+    "exponential",
+    "inverse_gaussian",
+    "quantile",
 ]
 Link = Literal[
     "identity",
@@ -62,7 +68,15 @@ FeatureType = Literal["categorical", "linear", "spline"]
 # tracker and changelog.txt respectively; see
 # https://github.com/rwilson4/gamdist/issues for the current roadmap.
 
-FAMILIES = ["normal", "binomial", "poisson", "gamma", "exponential", "inverse_gaussian"]
+FAMILIES = [
+    "normal",
+    "binomial",
+    "poisson",
+    "gamma",
+    "exponential",
+    "inverse_gaussian",
+    "quantile",
+]
 
 LINKS = [
     "identity",
@@ -74,7 +88,7 @@ LINKS = [
     "reciprocal_squared",
 ]
 
-FAMILIES_WITH_KNOWN_DISPERSIONS = {"binomial": 1, "poisson": 1}
+FAMILIES_WITH_KNOWN_DISPERSIONS = {"binomial": 1, "poisson": 1, "quantile": 1}
 
 CANONICAL_LINKS = {
     "normal": "identity",
@@ -82,6 +96,7 @@ CANONICAL_LINKS = {
     "poisson": "log",
     "gamma": "reciprocal",
     "inverse_gaussian": "reciprocal_squared",
+    "quantile": "identity",
 }
 # Non-canonical but common link/family combinations include:
 # Binomial: probit and complementary log-log
@@ -211,6 +226,7 @@ class GAM:
         estimate_overdispersion: bool = False,
         name: str | None = None,
         load_from_file: str | None = None,
+        tau: float | None = None,
     ) -> None:
         """Generalized Additive Model
 
@@ -293,6 +309,10 @@ class GAM:
              the left off by saving results (see the save_flag in .fit)
              and loading them to start the next iterations. Specifying
              this option supercedes all other parameters.
+         tau : float or None (optional)
+             Quantile level in (0, 1) for ``family='quantile'`` (pinball
+             loss). ``tau=0.5`` recovers the conditional median.
+             Required when ``family='quantile'`` and ignored otherwise.
 
         Returns
         -------
@@ -321,6 +341,20 @@ class GAM:
             self._link = link
         else:
             raise ValueError(f"{link} link not supported")
+
+        if self._family == "quantile":
+            if tau is None:
+                raise ValueError("tau must be specified for the quantile family.")
+            if not (0.0 < tau < 1.0):
+                raise ValueError(f"tau must be in (0, 1); got {tau}.")
+            if self._link != "identity":
+                raise ValueError(
+                    "quantile family requires link='identity'; "
+                    f"got link={self._link!r}."
+                )
+            self._tau: float | None = float(tau)
+        else:
+            self._tau = None
 
         if dispersion is not None:
             self._known_dispersion = True
@@ -372,6 +406,7 @@ class GAM:
         mv["known_dispersion"] = self._known_dispersion
         if self._known_dispersion:
             mv["dispersion"] = self._dispersion
+        mv["tau"] = self._tau
 
         mv["estimate_overdispersion"] = self._estimate_overdispersion
         mv["offset"] = self._offset
@@ -418,6 +453,7 @@ class GAM:
         self._known_dispersion = mv["known_dispersion"]
         if self._known_dispersion:
             self._dispersion = mv["dispersion"]
+        self._tau = mv.get("tau")
 
         self._estimate_overdispersion = mv["estimate_overdispersion"]
         self._offset = mv["offset"]
@@ -718,7 +754,15 @@ class GAM:
         else:
             self._has_covariate_classes = False
             self._covariate_class_sizes = None
-            self._offset = float(self._eval_link(np.mean(self._y)))
+            if self._family == "quantile":
+                # The offset anchors the model's average prediction over
+                # training data, since features are mean-zero. For
+                # quantile regression that anchor must be the marginal
+                # tau-quantile, not the mean.
+                assert self._tau is not None
+                self._offset = float(np.quantile(self._y, self._tau))
+            else:
+                self._offset = float(self._eval_link(np.mean(self._y)))
 
         fj: dict[str, FloatArray] = {}
 
@@ -954,6 +998,14 @@ class GAM:
                 po._prox_inv_gaussian_reciprocal_squared
                 if self._link == "reciprocal_squared"
                 else po._prox_inv_gaussian
+            )
+        elif self._family == "quantile":
+            return (1.0 / N) * po._prox_quantile_identity(
+                N * upf,
+                self._rho,
+                self._y,
+                self._tau,  # type: ignore[arg-type]
+                w=self._weights,
             )
         else:
             raise ValueError(
@@ -1451,6 +1503,18 @@ class GAM:
             if w is None:
                 return float(np.sum((y - mu) * (y - mu) / (mu * mu * y)))
             return float(w.dot((y - mu) * (y - mu) / (mu * mu * y)))
+        if self._family == "quantile":
+            # Pinball loss: rho_tau(r) = max(tau*r, (tau-1)*r). The
+            # quantile family has no proper likelihood, so "deviance"
+            # here is twice the empirical pinball loss -- the
+            # M-estimator analogue of -2 * log-likelihood used by the
+            # ADMM convergence trace and goodness-of-fit summaries.
+            tau = float(self._tau)  # type: ignore[arg-type]
+            r = y - mu
+            term = np.maximum(tau * r, (tau - 1.0) * r)
+            if w is None:
+                return float(2.0 * np.sum(term))
+            return float(2.0 * w.dot(term))
         raise ValueError(f"Unsupported family {self._family!r}")
 
     def dispersion(self, formula: str = "deviance") -> float:
@@ -1510,6 +1574,10 @@ class GAM:
             if self._known_dispersion:
                 return float(self._dispersion)
             return float(self.deviance() / (self._num_obs - self.dof()))
+        if self._family == "quantile":
+            # Pinball loss is an M-estimator, not a likelihood; there
+            # is no dispersion to estimate.
+            return 1.0
         raise ValueError(f"Unsupported family {self._family!r}")
 
     def _binomial_overdispersion(self, formula: str | None = None) -> float:

--- a/gamdist/proximal_operators.py
+++ b/gamdist/proximal_operators.py
@@ -390,3 +390,32 @@ def _prox_inv_gaussian(
     return np.array(
         [minimize_scalar(obj_fun_w, args=(v[i], y[i], w[i])).x for i in range(len(v))]
     )
+
+
+def _prox_quantile_identity(
+    v: FloatArray,
+    mu: float,
+    y: FloatArray,
+    tau: float,
+    w: FloatArray | None = None,
+    inv_link: InvLink | None = None,
+    p: Any = None,
+) -> FloatArray:
+    r"""Proximal operator for the pinball / check loss with identity link.
+
+    Solves, elementwise,
+        argmin_x  w * rho_tau(y - x) + (mu/2) * (x - v)^2
+    where ``rho_tau(r) = max(tau * r, (tau - 1) * r)`` is the pinball loss
+    parameterized by quantile level ``tau in (0, 1)``. The minimum is
+    attained in closed form via a shifted soft-threshold:
+        x* = v + w*tau/mu          if y > v + w*tau/mu        (overshoot)
+        x* = v - w*(1-tau)/mu      if y < v - w*(1-tau)/mu    (undershoot)
+        x* = y                     otherwise.
+    """
+    if w is None:
+        upper = v + tau / mu
+        lower = v - (1.0 - tau) / mu
+    else:
+        upper = v + (w * tau) / mu
+        lower = v - (w * (1.0 - tau)) / mu
+    return np.where(y > upper, upper, np.where(y < lower, lower, y))

--- a/tests/test_proximal_operators.py
+++ b/tests/test_proximal_operators.py
@@ -109,3 +109,78 @@ def test_poisson_log_scalar_handles_extreme_v() -> None:
     # Newton; the cap + damping keeps the result finite.
     out = po._prox_poisson_log_scalar([20.0, 0.1, 0.0])
     assert np.isfinite(out)
+
+
+def _pinball(r: float, tau: float) -> float:
+    return float(max(tau * r, (tau - 1.0) * r))
+
+
+def test_quantile_identity_matches_brute_force_optimum() -> None:
+    # Prox solves min_x  rho_tau(y - x) + (mu/2) (x - v)^2 in closed
+    # form; spot-check it against minimize_scalar on the same scalar
+    # objective across (v, y) sign combinations and tau values.
+    from scipy.optimize import minimize_scalar
+
+    rng = np.random.default_rng(0)
+    mu = 1.7
+    for tau in (0.1, 0.5, 0.75):
+        v = rng.normal(size=20)
+        y = rng.normal(size=20)
+        out = po._prox_quantile_identity(v, mu, y, tau=tau)
+        for i in range(len(v)):
+
+            def obj(
+                x: float, _v: float = v[i], _y: float = y[i], _tau: float = tau
+            ) -> float:
+                return _pinball(_y - x, _tau) + 0.5 * mu * (x - _v) ** 2
+
+            expected = float(minimize_scalar(obj).x)
+            assert abs(out[i] - expected) < 1e-5
+
+
+def test_quantile_identity_thresholds_and_passthrough() -> None:
+    # Targets sandwiched between the upper and lower thresholds pass
+    # through unchanged; outside, the prox saturates to the relevant
+    # shifted-soft-threshold corner.
+    mu = 2.0
+    tau = 0.3
+    v = np.array([0.0, 0.0, 0.0])
+    upper = tau / mu  # +0.15
+    lower = -(1.0 - tau) / mu  # -0.35
+    y = np.array([upper - 0.05, upper + 0.5, lower - 0.5])
+    out = po._prox_quantile_identity(v, mu, y, tau=tau)
+    np.testing.assert_allclose(out, [upper - 0.05, upper, lower], rtol=0, atol=1e-12)
+
+
+def test_quantile_identity_with_weights() -> None:
+    # Per-observation weights scale the pinball term; the prox should
+    # pick that up by widening / narrowing the interior pass-through
+    # region in the same closed-form way.
+    from scipy.optimize import minimize_scalar
+
+    mu = 1.0
+    tau = 0.4
+    v = np.array([0.2, -0.5, 1.0])
+    y = np.array([2.0, -2.0, 0.5])
+    w = np.array([0.5, 1.5, 1.0])
+    out = po._prox_quantile_identity(v, mu, y, tau=tau, w=w)
+    for i in range(len(v)):
+
+        def obj(
+            x: float, _v: float = v[i], _y: float = y[i], _w: float = w[i]
+        ) -> float:
+            return _w * _pinball(_y - x, tau) + 0.5 * mu * (x - _v) ** 2
+
+        expected = float(minimize_scalar(obj).x)
+        assert abs(out[i] - expected) < 1e-5
+
+
+def test_quantile_median_is_symmetric_soft_threshold() -> None:
+    # tau=0.5 collapses to the symmetric soft-threshold of the L1 prox,
+    # with half-width 1/(2*mu) on each side of v.
+    mu = 4.0
+    v = np.array([0.0, 0.0, 0.0, 0.0])
+    half = 0.5 / mu
+    y = np.array([0.0, half - 1e-6, half + 1.0, -half - 1.0])
+    out = po._prox_quantile_identity(v, mu, y, tau=0.5)
+    np.testing.assert_allclose(out, [0.0, half - 1e-6, half, -half], atol=1e-12)

--- a/tests/test_quantile.py
+++ b/tests/test_quantile.py
@@ -1,0 +1,123 @@
+"""End-to-end tests for the quantile (pinball-loss) family."""
+
+from __future__ import annotations
+
+import os
+import tempfile
+
+import numpy as np
+import pandas as pd
+import pytest
+from scipy.stats import norm
+
+from gamdist import GAM
+
+
+def _heteroskedastic_data(
+    n: int, seed: int
+) -> tuple[pd.DataFrame, np.ndarray, np.ndarray]:
+    """y_i = x_i + (1 + x_i) * eps_i with eps_i ~ N(0, 1).
+
+    The conditional tau-quantile is then linear in x, namely
+    ``x + (1 + x) * Phi^{-1}(tau)``, so a single linear feature suffices
+    to represent it exactly.
+    """
+    rng = np.random.default_rng(seed)
+    x = rng.uniform(0.0, 1.0, size=n)
+    eps = rng.normal(size=n)
+    y = x + (1.0 + x) * eps
+    X = pd.DataFrame({"x": x})
+    return X, y, x
+
+
+def _true_quantile(x: np.ndarray, tau: float) -> np.ndarray:
+    return x + (1.0 + x) * float(norm.ppf(tau))
+
+
+@pytest.mark.parametrize("tau", [0.1, 0.5, 0.9])
+def test_quantile_recovers_conditional_quantile(tau: float) -> None:
+    X_train, y_train, _ = _heteroskedastic_data(n=4000, seed=11 + int(tau * 100))
+    X_test, _, x_test = _heteroskedastic_data(n=400, seed=999)
+
+    mdl = GAM(family="quantile", tau=tau)
+    mdl.add_feature(name="x", type="linear")
+    mdl.fit(X_train, y_train, max_its=200)
+
+    yhat = mdl.predict(X_test)
+    truth = _true_quantile(x_test, tau)
+
+    err = float(np.sqrt(np.mean((yhat - truth) ** 2)))
+    assert err < 0.15, f"tau={tau}: rmse vs. true quantile = {err}"
+
+
+@pytest.mark.parametrize("tau", [0.2, 0.8])
+def test_quantile_empirical_coverage_matches_tau(tau: float) -> None:
+    # On a held-out sample, the fraction of observations falling below
+    # the predicted tau-quantile should be ~tau. That is the operational
+    # contract of a quantile regression and a tau-agnostic check.
+    X_train, y_train, _ = _heteroskedastic_data(n=4000, seed=31 + int(tau * 100))
+    X_test, y_test, _ = _heteroskedastic_data(n=2000, seed=131 + int(tau * 100))
+
+    mdl = GAM(family="quantile", tau=tau)
+    mdl.add_feature(name="x", type="linear")
+    mdl.fit(X_train, y_train, max_its=200)
+
+    yhat = mdl.predict(X_test)
+    coverage = float(np.mean(y_test <= yhat))
+    assert abs(coverage - tau) < 0.05, f"tau={tau}: coverage={coverage}"
+
+
+def test_quantile_requires_tau() -> None:
+    with pytest.raises(ValueError, match="tau"):
+        GAM(family="quantile")
+
+
+@pytest.mark.parametrize("bad_tau", [0.0, 1.0, -0.1, 1.5])
+def test_quantile_rejects_tau_out_of_range(bad_tau: float) -> None:
+    with pytest.raises(ValueError, match="tau"):
+        GAM(family="quantile", tau=bad_tau)
+
+
+def test_quantile_rejects_non_identity_link() -> None:
+    with pytest.raises(ValueError, match="identity"):
+        GAM(family="quantile", link="log", tau=0.5)
+
+
+def test_quantile_deviance_matches_pinball_loss() -> None:
+    rng = np.random.default_rng(7)
+    n = 200
+    X = pd.DataFrame({"x": rng.normal(size=n)})
+    y = X["x"].values + rng.normal(size=n) * 0.5
+
+    mdl = GAM(family="quantile", tau=0.3)
+    mdl.add_feature(name="x", type="linear")
+    mdl.fit(X, y, max_its=100)
+
+    pred = mdl.predict(X)
+    r = y - pred
+    expected = 2.0 * float(np.sum(np.maximum(0.3 * r, (0.3 - 1.0) * r)))
+    assert mdl.deviance() == pytest.approx(expected, rel=1e-6, abs=1e-9)
+
+
+def test_quantile_save_load_roundtrip() -> None:
+    rng = np.random.default_rng(0)
+    n = 200
+    X = pd.DataFrame({"x": rng.normal(size=n)})
+    y = X["x"].values + rng.normal(size=n)
+
+    with tempfile.TemporaryDirectory() as tmp:
+        cwd = os.getcwd()
+        os.chdir(tmp)
+        try:
+            mdl = GAM(family="quantile", tau=0.7, name="quantile_roundtrip")
+            mdl.add_feature(name="x", type="linear")
+            mdl.fit(X, y, max_its=50, save_flag=True)
+            yhat_before = mdl.predict(X)
+
+            mdl2 = GAM(load_from_file="quantile_roundtrip_model.pckl")
+        finally:
+            os.chdir(cwd)
+
+        assert mdl2._family == "quantile"
+        assert mdl2._tau == pytest.approx(0.7)
+        np.testing.assert_allclose(mdl2.predict(X), yhat_before, rtol=1e-12)


### PR DESCRIPTION
Adds family="quantile" with required tau in (0, 1). Closed-form
shifted-soft-threshold prox in proximal_operators._prox_quantile_identity
plugs into the existing (family, link) dispatch with no ADMM-loop
changes. The training offset is anchored at the marginal tau-quantile of
y so the mean-zero feature decomposition can reach the right intercept
for tau != 0.5.

Closes #22.

https://claude.ai/code/session_017A42mZAhrECYYSRZ8CN2jT