### PR TITLE
feat: huber (M-estimator) family for robust continuous regression

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,42 @@
+2026-04-26 : Huber (M-estimator) family for robust continuous regression
+- GAM now accepts family="huber" with a required positive `delta`
+  parameter in the units of `y`. Only link="identity" is supported
+  (the M-estimator framing is convex only at the identity link);
+  other links raise up front. Residuals with |y - mu| <= delta are
+  penalized as 0.5 * r^2; larger residuals are penalized linearly,
+  capping their per-observation influence. This is the standard
+  bounded-influence robust regression loss.
+- Closed-form prox in gamdist/proximal_operators.py:
+  _prox_huber_identity is a clipped weighted-mean shrinkage,
+      x* = v + w*delta/mu               if y - v >  delta*(mu+w)/mu
+      x* = v - w*delta/mu               if y - v < -delta*(mu+w)/mu
+      x* = (w*y + mu*v) / (w + mu)      otherwise.
+  The inner branch matches the normal-identity prox; the outer
+  branches saturate at v +/- w*delta/mu, which is what gives Huber
+  its bounded influence. No ADMM-loop changes; per-feature primal
+  steps see only fpumz and rho exactly as before.
+- The training offset (which anchors the model's average prediction,
+  since every feature is mean-zero) is set to np.median(y) for the
+  huber family. The median is the L1 limit of the Huber M-estimator
+  of location and a robust anchor regardless of delta.
+- _deviance_from_mu reports 2 * sum(L_delta(y - mu)) for the huber
+  family (the M-estimator analogue of -2 * log-likelihood used by the
+  convergence trace and AIC/BIC summaries); dispersion() is fixed at
+  1.0. huber is added to FAMILIES_WITH_KNOWN_DISPERSIONS so AIC/BIC
+  don't add a phantom DOF for an estimated dispersion.
+- delta is persisted in save/load; older pickles default delta to None.
+- Tests in tests/test_proximal_operators.py cover the prox vs.
+  scipy.optimize.minimize_scalar across delta values that span the
+  inner / outer regimes, the quadratic-region collapse to the
+  normal-identity prox at large delta, the outer-region corner
+  saturation, the weighted variant, and continuity at the threshold.
+  tests/test_huber.py adds an end-to-end test that Huber recovers the
+  underlying slope on outlier-contaminated data more accurately than
+  OLS, that delta -> infinity collapses to OLS on clean data, the
+  delta-required / non-positive-delta / non-identity-link API
+  validations, the deviance = 2 * sum(huber_loss) identity, and a
+  save/load round-trip. Closes #21.
+
 2026-04-26 : Quantile (pinball-loss) family for conditional quantile regression
 - GAM now accepts family="quantile" with a required tau parameter in
   (0, 1). Only link="identity" is supported (the M-estimator framing

--- a/gamdist/gamdist.py
+++ b/gamdist/gamdist.py
@@ -52,6 +52,7 @@ Family = Literal[
     "exponential",
     "inverse_gaussian",
     "quantile",
+    "huber",
 ]
 Link = Literal[
     "identity",
@@ -76,6 +77,7 @@ FAMILIES = [
     "exponential",
     "inverse_gaussian",
     "quantile",
+    "huber",
 ]
 
 LINKS = [
@@ -88,7 +90,12 @@ LINKS = [
     "reciprocal_squared",
 ]
 
-FAMILIES_WITH_KNOWN_DISPERSIONS = {"binomial": 1, "poisson": 1, "quantile": 1}
+FAMILIES_WITH_KNOWN_DISPERSIONS = {
+    "binomial": 1,
+    "poisson": 1,
+    "quantile": 1,
+    "huber": 1,
+}
 
 CANONICAL_LINKS = {
     "normal": "identity",
@@ -97,6 +104,7 @@ CANONICAL_LINKS = {
     "gamma": "reciprocal",
     "inverse_gaussian": "reciprocal_squared",
     "quantile": "identity",
+    "huber": "identity",
 }
 # Non-canonical but common link/family combinations include:
 # Binomial: probit and complementary log-log
@@ -227,6 +235,7 @@ class GAM:
         name: str | None = None,
         load_from_file: str | None = None,
         tau: float | None = None,
+        delta: float | None = None,
     ) -> None:
         """Generalized Additive Model
 
@@ -264,7 +273,9 @@ class GAM:
                 'binomial' (for binary responses),
                 'poisson' (for counts),
                 'gamma' (still in progress),
-                'inverse_gaussian' (still in progress).
+                'inverse_gaussian' (still in progress),
+                'quantile' (pinball loss; requires ``tau``),
+                'huber' (robust M-estimator; requires ``delta``).
              Not currently supported families that could be supported
              include Multinomial models (ordinal and nominal) and
              proportional hazards models. Required unless loading an
@@ -313,6 +324,13 @@ class GAM:
              Quantile level in (0, 1) for ``family='quantile'`` (pinball
              loss). ``tau=0.5`` recovers the conditional median.
              Required when ``family='quantile'`` and ignored otherwise.
+         delta : float or None (optional)
+             Knee parameter for ``family='huber'``. Residuals with
+             ``|y - mu| <= delta`` are penalized as ``0.5 * r^2`` (least
+             squares); larger residuals are penalized linearly, capping
+             their per-observation influence. Must be positive and is in
+             the units of ``y``. Required when ``family='huber'`` and
+             ignored otherwise.
 
         Returns
         -------
@@ -355,6 +373,19 @@ class GAM:
             self._tau: float | None = float(tau)
         else:
             self._tau = None
+
+        if self._family == "huber":
+            if delta is None:
+                raise ValueError("delta must be specified for the huber family.")
+            if not (delta > 0.0):
+                raise ValueError(f"delta must be positive; got {delta}.")
+            if self._link != "identity":
+                raise ValueError(
+                    f"huber family requires link='identity'; got link={self._link!r}."
+                )
+            self._delta: float | None = float(delta)
+        else:
+            self._delta = None
 
         if dispersion is not None:
             self._known_dispersion = True
@@ -407,6 +438,7 @@ class GAM:
         if self._known_dispersion:
             mv["dispersion"] = self._dispersion
         mv["tau"] = self._tau
+        mv["delta"] = self._delta
 
         mv["estimate_overdispersion"] = self._estimate_overdispersion
         mv["offset"] = self._offset
@@ -454,6 +486,7 @@ class GAM:
         if self._known_dispersion:
             self._dispersion = mv["dispersion"]
         self._tau = mv.get("tau")
+        self._delta = mv.get("delta")
 
         self._estimate_overdispersion = mv["estimate_overdispersion"]
         self._offset = mv["offset"]
@@ -761,6 +794,11 @@ class GAM:
                 # tau-quantile, not the mean.
                 assert self._tau is not None
                 self._offset = float(np.quantile(self._y, self._tau))
+            elif self._family == "huber":
+                # Huber loss is robust; the median is the L1 limit of
+                # its M-estimator and a sensible anchor regardless of
+                # delta.
+                self._offset = float(np.median(self._y))
             else:
                 self._offset = float(self._eval_link(np.mean(self._y)))
 
@@ -1005,6 +1043,14 @@ class GAM:
                 self._rho,
                 self._y,
                 self._tau,  # type: ignore[arg-type]
+                w=self._weights,
+            )
+        elif self._family == "huber":
+            return (1.0 / N) * po._prox_huber_identity(
+                N * upf,
+                self._rho,
+                self._y,
+                self._delta,  # type: ignore[arg-type]
                 w=self._weights,
             )
         else:
@@ -1515,6 +1561,18 @@ class GAM:
             if w is None:
                 return float(2.0 * np.sum(term))
             return float(2.0 * w.dot(term))
+        if self._family == "huber":
+            # Huber loss is an M-estimator without a proper likelihood;
+            # report 2 * sum(L_delta(y - mu)) so the inner (quadratic)
+            # region matches normal-family deviance and the convergence
+            # trace stays comparable across runs.
+            delta = float(self._delta)  # type: ignore[arg-type]
+            r = y - mu
+            abs_r = np.abs(r)
+            term = np.where(abs_r <= delta, 0.5 * r * r, delta * (abs_r - 0.5 * delta))
+            if w is None:
+                return float(2.0 * np.sum(term))
+            return float(2.0 * w.dot(term))
         raise ValueError(f"Unsupported family {self._family!r}")
 
     def dispersion(self, formula: str = "deviance") -> float:
@@ -1577,6 +1635,11 @@ class GAM:
         if self._family == "quantile":
             # Pinball loss is an M-estimator, not a likelihood; there
             # is no dispersion to estimate.
+            return 1.0
+        if self._family == "huber":
+            # Huber is an M-estimator. There is no dispersion in the
+            # likelihood sense; sandwich SEs would be the right inferential
+            # tool (#34) but are out of scope here.
             return 1.0
         raise ValueError(f"Unsupported family {self._family!r}")
 

--- a/gamdist/proximal_operators.py
+++ b/gamdist/proximal_operators.py
@@ -392,6 +392,45 @@ def _prox_inv_gaussian(
     )
 
 
+def _prox_huber_identity(
+    v: FloatArray,
+    mu: float,
+    y: FloatArray,
+    delta: float,
+    w: FloatArray | None = None,
+    inv_link: InvLink | None = None,
+    p: Any = None,
+) -> FloatArray:
+    r"""Proximal operator for the Huber loss with identity link.
+
+    Solves, elementwise,
+        argmin_x  w * L_delta(y - x) + (mu/2) * (x - v)^2
+    where ``L_delta(r) = 0.5 r^2`` for ``|r| <= delta`` and
+    ``L_delta(r) = delta * (|r| - 0.5*delta)`` for ``|r| > delta`` is the
+    Huber loss with knee ``delta > 0``. The minimum has a closed form:
+    a clipped weighted-mean shrinkage, with the linear-region branches
+    saturating at ``v +/- w*delta/mu``.
+        x* = v + w*delta/mu                 if y - v >   delta*(mu+w)/mu
+        x* = v - w*delta/mu                 if y - v <  -delta*(mu+w)/mu
+        x* = (w*y + mu*v) / (w + mu)        otherwise.
+    Reduces to the normal-identity prox in the inner (quadratic) region
+    and to a soft-threshold-style clip in the outer (linear) region;
+    bounded influence is what makes Huber robust to outliers.
+    """
+    if w is None:
+        threshold: FloatArray | float = delta * (1.0 + mu) / mu
+        upper = v + delta / mu
+        lower = v - delta / mu
+        quad = (y + mu * v) / (1.0 + mu)
+    else:
+        threshold = delta * (w + mu) / mu
+        upper = v + (w * delta) / mu
+        lower = v - (w * delta) / mu
+        quad = (w * y + mu * v) / (w + mu)
+    diff = y - v
+    return np.where(diff > threshold, upper, np.where(diff < -threshold, lower, quad))
+
+
 def _prox_quantile_identity(
     v: FloatArray,
     mu: float,

--- a/tests/test_huber.py
+++ b/tests/test_huber.py
@@ -1,0 +1,151 @@
+"""End-to-end tests for the huber (M-estimator) family."""
+
+from __future__ import annotations
+
+import os
+import tempfile
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from gamdist import GAM
+
+
+def _huber_loss(r: np.ndarray, delta: float) -> np.ndarray:
+    abs_r = np.abs(r)
+    return np.where(abs_r <= delta, 0.5 * r * r, delta * (abs_r - 0.5 * delta))
+
+
+def _contaminated_data(
+    n: int, seed: int, outlier_frac: float = 0.1
+) -> tuple[pd.DataFrame, np.ndarray]:
+    """y = 1 + 2x + eps with a fraction of large-magnitude outliers in eps."""
+    rng = np.random.default_rng(seed)
+    x = rng.uniform(-1.0, 1.0, size=n)
+    eps = rng.normal(size=n) * 0.2
+    n_out = int(round(outlier_frac * n))
+    if n_out > 0:
+        idx = rng.choice(n, size=n_out, replace=False)
+        eps[idx] = rng.choice([-1.0, 1.0], size=n_out) * rng.uniform(
+            5.0, 10.0, size=n_out
+        )
+    y = 1.0 + 2.0 * x + eps
+    return pd.DataFrame({"x": x}), y
+
+
+def test_huber_recovers_slope_under_outliers() -> None:
+    # Huber loss should track the underlying slope despite contamination
+    # that knocks the OLS estimate around. Both fit on the same training
+    # set; the Huber slope ends up closer to the truth (2.0).
+    X_train, y_train = _contaminated_data(n=600, seed=0, outlier_frac=0.15)
+    truth = 2.0
+
+    huber = GAM(family="huber", delta=1.0)
+    huber.add_feature(name="x", type="linear")
+    huber.fit(X_train, y_train, max_its=200)
+
+    ols = GAM(family="normal")
+    ols.add_feature(name="x", type="linear")
+    ols.fit(X_train, y_train, max_its=200)
+
+    # The Huber slope should be at least as close to truth as OLS, and
+    # should be within a small tolerance of truth on this data size.
+    huber_slope = float(huber._features["x"]._m)  # type: ignore[attr-defined]
+    ols_slope = float(ols._features["x"]._m)  # type: ignore[attr-defined]
+    assert abs(huber_slope - truth) < abs(ols_slope - truth)
+    assert abs(huber_slope - truth) < 0.2
+
+
+def test_huber_large_delta_approaches_normal() -> None:
+    # With delta much larger than any residual, Huber loss collapses to
+    # 0.5 * r^2 elementwise, so the fit should match normal-family OLS
+    # on clean Gaussian data.
+    rng = np.random.default_rng(3)
+    n = 400
+    x = rng.normal(size=n)
+    y = 0.5 + 1.5 * x + rng.normal(size=n) * 0.1
+    X = pd.DataFrame({"x": x})
+
+    huber = GAM(family="huber", delta=1e6)
+    huber.add_feature(name="x", type="linear")
+    huber.fit(X, y, max_its=200)
+
+    ols = GAM(family="normal")
+    ols.add_feature(name="x", type="linear")
+    ols.fit(X, y, max_its=200)
+
+    np.testing.assert_allclose(huber.predict(X), ols.predict(X), atol=1e-2)
+
+
+def test_huber_requires_delta() -> None:
+    with pytest.raises(ValueError, match="delta"):
+        GAM(family="huber")
+
+
+@pytest.mark.parametrize("bad_delta", [0.0, -0.5, -1e-12])
+def test_huber_rejects_non_positive_delta(bad_delta: float) -> None:
+    with pytest.raises(ValueError, match="delta"):
+        GAM(family="huber", delta=bad_delta)
+
+
+def test_huber_rejects_non_identity_link() -> None:
+    with pytest.raises(ValueError, match="identity"):
+        GAM(family="huber", link="log", delta=1.0)
+
+
+def test_huber_canonical_link_is_identity() -> None:
+    mdl = GAM(family="huber", delta=1.0)
+    assert mdl._link == "identity"
+
+
+def test_huber_dispersion_is_one() -> None:
+    rng = np.random.default_rng(0)
+    n = 100
+    X = pd.DataFrame({"x": rng.normal(size=n)})
+    y = X["x"].values + rng.normal(size=n) * 0.5
+
+    mdl = GAM(family="huber", delta=1.0)
+    mdl.add_feature(name="x", type="linear")
+    mdl.fit(X, y, max_its=50)
+    assert mdl.dispersion() == 1.0
+
+
+def test_huber_deviance_matches_huber_loss_sum() -> None:
+    rng = np.random.default_rng(7)
+    n = 200
+    X = pd.DataFrame({"x": rng.normal(size=n)})
+    y = X["x"].values + rng.normal(size=n) * 0.5
+
+    delta = 0.7
+    mdl = GAM(family="huber", delta=delta)
+    mdl.add_feature(name="x", type="linear")
+    mdl.fit(X, y, max_its=100)
+
+    pred = mdl.predict(X)
+    expected = 2.0 * float(np.sum(_huber_loss(y - pred, delta)))
+    assert mdl.deviance() == pytest.approx(expected, rel=1e-6, abs=1e-9)
+
+
+def test_huber_save_load_roundtrip() -> None:
+    rng = np.random.default_rng(0)
+    n = 200
+    X = pd.DataFrame({"x": rng.normal(size=n)})
+    y = X["x"].values + rng.normal(size=n)
+
+    with tempfile.TemporaryDirectory() as tmp:
+        cwd = os.getcwd()
+        os.chdir(tmp)
+        try:
+            mdl = GAM(family="huber", delta=1.5, name="huber_roundtrip")
+            mdl.add_feature(name="x", type="linear")
+            mdl.fit(X, y, max_its=50, save_flag=True)
+            yhat_before = mdl.predict(X)
+
+            mdl2 = GAM(load_from_file="huber_roundtrip_model.pckl")
+        finally:
+            os.chdir(cwd)
+
+        assert mdl2._family == "huber"
+        assert mdl2._delta == pytest.approx(1.5)
+        np.testing.assert_allclose(mdl2.predict(X), yhat_before, rtol=1e-12)

--- a/tests/test_proximal_operators.py
+++ b/tests/test_proximal_operators.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import numpy as np
+import pytest
 
 from gamdist import proximal_operators as po
 
@@ -184,3 +185,99 @@ def test_quantile_median_is_symmetric_soft_threshold() -> None:
     y = np.array([0.0, half - 1e-6, half + 1.0, -half - 1.0])
     out = po._prox_quantile_identity(v, mu, y, tau=0.5)
     np.testing.assert_allclose(out, [0.0, half - 1e-6, half, -half], atol=1e-12)
+
+
+def _huber_scalar_loss(r: float, delta: float) -> float:
+    abs_r = abs(r)
+    if abs_r <= delta:
+        return 0.5 * r * r
+    return delta * (abs_r - 0.5 * delta)
+
+
+def test_huber_identity_matches_brute_force_optimum() -> None:
+    # Prox solves min_x  L_delta(y - x) + (mu/2) (x - v)^2 in closed
+    # form; spot-check it against minimize_scalar across (v, y) draws
+    # and a few delta values that span the inner / outer regimes.
+    from scipy.optimize import minimize_scalar
+
+    rng = np.random.default_rng(0)
+    mu = 2.3
+    for delta in (0.2, 1.0, 3.0):
+        v = rng.normal(scale=2.0, size=20)
+        y = rng.normal(scale=2.0, size=20)
+        out = po._prox_huber_identity(v, mu, y, delta=delta)
+        for i in range(len(v)):
+
+            def obj(
+                x: float, _v: float = v[i], _y: float = y[i], _delta: float = delta
+            ) -> float:
+                return _huber_scalar_loss(_y - x, _delta) + 0.5 * mu * (x - _v) ** 2
+
+            expected = float(minimize_scalar(obj).x)
+            assert abs(out[i] - expected) < 1e-5
+
+
+def test_huber_identity_quadratic_region_matches_normal_prox() -> None:
+    # When all residuals stay inside the quadratic region (|y - v| small
+    # relative to delta * (1 + mu) / mu), the Huber prox reduces to the
+    # normal-identity prox: x* = (y + mu*v) / (1 + mu).
+    mu = 1.0
+    delta = 100.0
+    v = np.array([0.0, 1.0, -2.0])
+    y = np.array([0.5, 0.8, -1.7])
+    out = po._prox_huber_identity(v, mu, y, delta=delta)
+    expected = po._prox_normal_identity(v, mu, y)
+    np.testing.assert_allclose(out, expected, rtol=0, atol=1e-12)
+
+
+def test_huber_identity_outer_region_saturates_at_corner() -> None:
+    # Targets far above v + threshold land at the upper corner v + delta/mu;
+    # far below at v - delta/mu. The interior passes through the quadratic
+    # branch (y + mu*v) / (1 + mu).
+    mu = 2.0
+    delta = 0.5
+    v = np.array([0.0, 0.0, 0.0])
+    threshold = delta * (1.0 + mu) / mu  # 0.75
+    y = np.array([10.0, -10.0, 0.1])  # outer high, outer low, interior
+    out = po._prox_huber_identity(v, mu, y, delta=delta)
+    assert out[0] == pytest.approx(delta / mu)  # 0.25
+    assert out[1] == pytest.approx(-delta / mu)
+    assert out[2] == pytest.approx((0.1 + mu * 0.0) / (1.0 + mu))
+    assert threshold > 0.0  # sanity check on the math
+
+
+def test_huber_identity_with_weights() -> None:
+    # Per-observation weights scale the Huber term; the prox should
+    # widen the upper / lower corners and the threshold accordingly.
+    from scipy.optimize import minimize_scalar
+
+    mu = 1.0
+    delta = 0.5
+    v = np.array([0.2, -0.5, 1.0])
+    y = np.array([2.0, -2.0, 0.5])
+    w = np.array([0.5, 1.5, 1.0])
+    out = po._prox_huber_identity(v, mu, y, delta=delta, w=w)
+    for i in range(len(v)):
+
+        def obj(
+            x: float, _v: float = v[i], _y: float = y[i], _w: float = w[i]
+        ) -> float:
+            return _w * _huber_scalar_loss(_y - x, delta) + 0.5 * mu * (x - _v) ** 2
+
+        expected = float(minimize_scalar(obj).x)
+        assert abs(out[i] - expected) < 1e-5
+
+
+def test_huber_identity_continuous_at_threshold() -> None:
+    # The two branches must agree where they meet (y - v == +/- threshold);
+    # otherwise the prox would be discontinuous in y.
+    mu = 1.5
+    delta = 0.7
+    v = np.array([0.3, 0.3])
+    threshold = delta * (1.0 + mu) / mu
+    eps = 1e-9
+    y_just_inside = np.array([v[0] + threshold - eps, v[0] - threshold + eps])
+    y_just_outside = np.array([v[0] + threshold + eps, v[0] - threshold - eps])
+    inside = po._prox_huber_identity(v, mu, y_just_inside, delta=delta)
+    outside = po._prox_huber_identity(v, mu, y_just_outside, delta=delta)
+    np.testing.assert_allclose(inside, outside, atol=1e-7)


### PR DESCRIPTION
Adds family="huber" with required positive delta. Closed-form
clipped-weighted-mean prox in proximal_operators._prox_huber_identity
plugs into the existing (family, link) dispatch with no ADMM-loop
changes. The inner branch matches the normal-identity prox; the outer
branches saturate at v +/- w*delta/mu, which is what gives Huber its
bounded influence under outliers. Training offset is anchored at the
marginal median of y so the mean-zero feature decomposition starts from
a robust intercept.

Closes #21.

https://claude.ai/code/session_011i6xpNqfgE8rKem4NXKVJ4