### PR TITLE
feat: sandwich (Huber-White) covariance estimator

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,40 @@
+2026-04-26 : Sandwich (Huber-White) covariance estimator
+- GAM.robust_covariance(cov_type="HC0") returns the heteroscedasticity-
+  consistent sandwich estimator
+      V = (X' W X)^{-1} (X' diag(s_i^2) X) (X' W X)^{-1}
+  for the parameter vector defined by GAM._design_matrix(). Per
+  observation w_i = (dmu/deta)_i^2 / V(mu_i) is the IRLS weight and
+  s_i = (y_i - mu_i) (dmu/deta)_i / V(mu_i) is the eta-scale score;
+  mu is read off the fitted model. The dispersion drops out, so the
+  estimator is identical for known and estimated dispersion. cov_type=
+  "HC1" applies the n / (n - p) small-sample correction.
+- _design_matrix(X=None) builds an intercept + raw-linear + treatment-
+  contrast (drop lex-first level) categorical design that matches
+  statsmodels / patsy parametrization, so robust_covariance lines up
+  term-by-term with statsmodels.GLM(...).fit(cov_type="HC0").cov_params().
+- Supported families: normal, binomial, poisson, gamma, inverse_gaussian.
+  Spline features, binomial covariate classes, observation weights, and
+  the quantile / huber families raise NotImplementedError up front --
+  follow-on issues will extend coverage. Penalized fits return the
+  naive sandwich at the penalized point estimate; a bread that includes
+  the penalty Hessian is future work and is also flagged in the
+  docstring.
+- Foundational dependency for issue #35 (quasi-likelihood families):
+  with sandwich SEs in place, quasi_normal / quasi_binomial /
+  quasi_poisson can ship without inference being a separate workstream.
+- Tests in tests/test_robust_covariance.py: (a) inject statsmodels'
+  converged mu into gamdist and compare cov_params to numerical
+  precision (rtol=1e-10) -- pins the sandwich formula independent of
+  the optimizer, since gamdist's ADMM stops at eps_abs=eps_rel=1e-3
+  while statsmodels' IRLS goes to machine precision; (b) end-to-end
+  fit-and-compare with looser tolerances (rtol=5e-2) on the same three
+  families; (c) HC0 -> HC1 scaling identity; (d) design-matrix layout
+  invariants; (e) NotImplementedError gates for splines, the quantile
+  family, unsupported cov_type, and unfitted-model access. statsmodels
+  is gated via pytest.importorskip so the test module is silently
+  skipped in environments without it (statsmodels is not added to the
+  package's runtime or dev dependencies). Closes #34.
+
 2026-04-26 : Huber (M-estimator) family for robust continuous regression
 - GAM now accepts family="huber" with a required positive `delta`
   parameter in the units of `y`. Only link="identity" is supported

--- a/gamdist/gamdist.py
+++ b/gamdist/gamdist.py
@@ -1093,6 +1093,234 @@ class GAM:
 
         return np.asarray(self._eval_inv_link(eta), dtype=float)
 
+    def _design_matrix(
+        self, X: pd.DataFrame | None = None
+    ) -> tuple[FloatArray, list[str]]:
+        """Build a full-rank design matrix used by ``robust_covariance``.
+
+        Parametrization (matches ``statsmodels`` / ``patsy`` defaults):
+
+        * column 0: intercept (all ones)
+        * one column per linear feature: the (transformed) raw values
+          ``transform(x)`` -- *not* mean-centered. Centering is a
+          reparametrization of the intercept and does not change the
+          fitted ``mu`` or the inferential conclusions on the linear
+          predictor; using raw columns makes the coefficient align with
+          ``statsmodels`` term-by-term.
+        * for each categorical feature with ``K`` levels: ``K - 1``
+          indicator columns dropping the lexicographically-first level
+          (treatment contrast), again matching ``statsmodels`` / ``patsy``.
+
+        Spline features and binomial covariate classes are not yet
+        wired up here and raise ``NotImplementedError``.
+
+        Parameters
+        ----------
+        X : pandas DataFrame or None
+            If ``None``, builds the design matrix from the training
+            data already absorbed by the features. If a frame is
+            supplied, its columns are looked up by feature name and
+            the per-feature design block is constructed at those
+            values (with the same dropped-category as training).
+
+        Returns
+        -------
+        D : (n, p) ndarray
+        names : list of str
+            Column names: ``"Intercept"`` followed by per-feature
+            labels (e.g. ``"purchases"``, ``"country[T.GBR]"``).
+        """
+        if not self._fitted:
+            raise AttributeError("Model not yet fit.")
+        if self._has_covariate_classes:
+            raise NotImplementedError(
+                "Inferential design matrix not yet supported for binomial "
+                "covariate classes."
+            )
+
+        if X is None:
+            n = self._num_obs
+        else:
+            n = len(X)
+
+        cols: list[FloatArray] = [np.ones(n, dtype=float)]
+        names: list[str] = ["Intercept"]
+
+        for fname, feature in self._features.items():
+            if isinstance(feature, _LinearFeature):
+                if X is None:
+                    block = np.asarray(feature._x + feature._xmean, dtype=float)
+                else:
+                    raw = np.asarray(X[fname].values)
+                    if feature._has_transform:
+                        block = np.asarray(feature._transform(raw), dtype=float)
+                    else:
+                        block = raw.astype(float)
+                cols.append(block)
+                names.append(fname)
+            elif isinstance(feature, _CategoricalFeature):
+                cats = sorted(feature._categories, key=str)
+                if X is None:
+                    raw = np.array(
+                        [feature._categories[idx] for idx in feature.x], dtype=object
+                    )
+                else:
+                    raw = np.asarray(X[fname].values)
+                # Drop the lexicographically-first level (treatment contrast).
+                for level in cats[1:]:
+                    cols.append(np.asarray(raw == level, dtype=float))
+                    names.append(f"{fname}[T.{level}]")
+            else:
+                raise NotImplementedError(
+                    f"Feature {fname!r} of type {feature.__type__!r} is not yet "
+                    "supported by robust_covariance / _design_matrix. Currently "
+                    "only linear and categorical features are wired up."
+                )
+
+        return np.column_stack(cols), names
+
+    def _glm_irls_terms(
+        self,
+        y: npt.NDArray[Any],
+        mu: FloatArray,
+    ) -> tuple[FloatArray, FloatArray]:
+        """Per-observation IRLS weight ``w`` and eta-scale score ``s``.
+
+        For a GLM with linear predictor ``eta``, mean ``mu = g^{-1}(eta)``
+        and variance function ``V(mu)``, the score and Fisher information
+        with respect to ``eta`` are
+
+            s_i = (y_i - mu_i) * (dmu/deta)_i / V(mu_i)
+            w_i = (dmu/deta)_i^2 / V(mu_i)
+
+        Together they give the sandwich pieces ``X' diag(w) X`` (bread)
+        and ``X' diag(s^2) X`` (meat).
+        """
+        if self._family == "normal":
+            v = np.ones_like(mu, dtype=float)
+        elif self._family == "binomial":
+            eps = np.finfo(float).eps
+            mu_c = np.clip(mu, eps, 1.0 - eps)
+            v = mu_c * (1.0 - mu_c)
+        elif self._family == "poisson":
+            v = mu
+        elif self._family == "gamma":
+            v = mu * mu
+        elif self._family == "inverse_gaussian":
+            v = mu * mu * mu
+        else:
+            raise NotImplementedError(
+                f"robust_covariance does not yet support the {self._family!r} "
+                "family. Supported: normal, binomial, poisson, gamma, "
+                "inverse_gaussian."
+            )
+
+        if self._link == "identity":
+            dmu_deta = np.ones_like(mu, dtype=float)
+        elif self._link == "log":
+            dmu_deta = mu
+        elif self._link == "logistic":
+            eps = np.finfo(float).eps
+            mu_c = np.clip(mu, eps, 1.0 - eps)
+            dmu_deta = mu_c * (1.0 - mu_c)
+        elif self._link == "probit":
+            # eta = Phi^{-1}(mu); dmu/deta = phi(eta)
+            eta = stats.norm.ppf(np.clip(mu, 1e-12, 1.0 - 1e-12))
+            dmu_deta = stats.norm.pdf(eta)
+        elif self._link == "complementary_log_log":
+            mu_c = np.clip(mu, 1e-12, 1.0 - 1e-12)
+            eta = np.log(-np.log(1.0 - mu_c))
+            dmu_deta = np.exp(eta) * (1.0 - mu_c)
+        elif self._link == "reciprocal":
+            dmu_deta = -mu * mu
+        elif self._link == "reciprocal_squared":
+            dmu_deta = -0.5 * mu * mu * mu
+        else:
+            raise NotImplementedError(
+                f"robust_covariance does not yet support the {self._link!r} link."
+            )
+
+        weight = dmu_deta * dmu_deta / v
+        score = (y - mu) * dmu_deta / v
+        return np.asarray(weight, dtype=float), np.asarray(score, dtype=float)
+
+    def robust_covariance(self, cov_type: str = "HC0") -> FloatArray:
+        """Sandwich (Huber-White) covariance estimator.
+
+        Returns the heteroscedasticity-consistent covariance for the
+        parameter vector defined by ``_design_matrix``:
+
+            V = (X' W X)^{-1} (X' diag(s_i^2) X) (X' W X)^{-1}
+
+        where ``W_ii = (dmu/deta)_i^2 / V(mu_i)`` is the IRLS weight
+        and ``s_i = (y_i - mu_i) (dmu/deta)_i / V(mu_i)`` is the
+        per-observation score on the ``eta`` scale. ``mu`` is the
+        fitted mean from this GAM. The dispersion drops out, so the
+        estimator is identical for known and estimated dispersion.
+
+        For canonical-link GLMs without regularization, the result
+        matches ``statsmodels.GLM(...).fit(cov_type="HC0").cov_params()``
+        on the same parametrization to numerical precision. Penalized
+        fits return the *naive* sandwich at the penalized point
+        estimate; for proper penalized inference a bread that includes
+        the penalty Hessian is needed (future work).
+
+        Parameters
+        ----------
+        cov_type : ``"HC0"`` or ``"HC1"``
+            ``"HC0"`` is the standard White estimator. ``"HC1"``
+            multiplies by ``n / (n - p)`` for a small-sample
+            correction (matches Stata / statsmodels HC1).
+
+        Returns
+        -------
+        V : (p, p) ndarray
+            Covariance for the parameter vector
+            ``(intercept, linear..., categorical contrasts...)``,
+            in the order produced by ``_design_matrix()``.
+
+        Raises
+        ------
+        AttributeError
+            If the model has not been fit.
+        NotImplementedError
+            For spline features, covariate classes, observation
+            weights, the quantile or huber families, or unsupported
+            ``cov_type`` values.
+        """
+        if cov_type not in ("HC0", "HC1"):
+            raise NotImplementedError(
+                f"cov_type={cov_type!r} not supported. Use 'HC0' or 'HC1'."
+            )
+        if not self._fitted:
+            raise AttributeError("Model not yet fit.")
+        if self._weights is not None:
+            raise NotImplementedError(
+                "robust_covariance does not yet support observation weights."
+            )
+        if self._family in ("quantile", "huber"):
+            raise NotImplementedError(
+                f"robust_covariance does not yet support family={self._family!r}; "
+                "M-estimator sandwich SEs are tracked separately."
+            )
+
+        D, _ = self._design_matrix()
+        mu = self._eval_inv_link(self._num_features * self.f_bar)
+        weight, score = self._glm_irls_terms(self._y, mu)
+
+        bread = D.T @ (weight[:, None] * D)
+        meat = D.T @ ((score * score)[:, None] * D)
+        bread_inv = linalg.inv(bread)
+        cov = bread_inv @ meat @ bread_inv
+
+        if cov_type == "HC1":
+            n = self._num_obs
+            p = D.shape[1]
+            if n > p:
+                cov = cov * (n / (n - p))
+
+        return np.asarray(cov, dtype=float)
+
     def confidence_intervals(
         self, X: pd.DataFrame, prediction: bool = False, width: float = 0.95
     ) -> FloatArray:

--- a/tests/test_robust_covariance.py
+++ b/tests/test_robust_covariance.py
@@ -1,0 +1,188 @@
+"""Sandwich (Huber-White) covariance estimator vs statsmodels.
+
+The sandwich estimator is a post-fit linear-algebra construction off
+the fitted ``mu`` -- it does not retrace the optimization path. So as
+long as gamdist's converged ``mu`` matches statsmodels' MLE on the
+same model, ``robust_covariance(cov_type='HC0')`` should match
+statsmodels' ``GLM(...).fit(cov_type='HC0').cov_params()`` exactly,
+modulo the optimization tolerance that separates the two fits.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from gamdist import GAM
+
+sm = pytest.importorskip("statsmodels.api")
+
+
+def _design_for_statsmodels(X: pd.DataFrame, mdl: GAM) -> np.ndarray:
+    """Mirror GAM._design_matrix in the statsmodels parametrization."""
+    D, _ = mdl._design_matrix(X)
+    return D
+
+
+def _gam_fit(family, link=None, **fit_kwargs):
+    rng = np.random.default_rng(7)
+    n = 600
+    x1 = rng.normal(size=n)
+    x2 = rng.uniform(-1.0, 2.0, size=n)
+    cat = rng.choice(["a", "b", "c"], size=n, p=[0.5, 0.3, 0.2])
+    cat_eff = np.where(cat == "a", 0.0, np.where(cat == "b", 0.4, -0.3))
+    eta = 0.5 + 0.7 * x1 - 0.3 * x2 + cat_eff
+
+    if family == "normal":
+        mu = eta
+        y = mu + rng.normal(scale=0.5, size=n)
+    elif family == "binomial":
+        mu = 1.0 / (1.0 + np.exp(-eta))
+        y = rng.binomial(1, mu).astype(float)
+    elif family == "poisson":
+        mu = np.exp(eta * 0.3)  # keep counts modest
+        y = rng.poisson(mu).astype(float)
+    else:
+        raise ValueError(family)
+
+    X = pd.DataFrame({"x1": x1, "x2": x2, "cat": cat})
+
+    mdl = GAM(family=family, link=link)
+    mdl.add_feature(name="x1", type="linear")
+    mdl.add_feature(name="x2", type="linear")
+    mdl.add_feature(name="cat", type="categorical")
+    mdl.fit(X, y, max_its=200, **fit_kwargs)
+    return mdl, X, y
+
+
+def _statsmodels_glm(family, X, y, mdl):
+    if family == "normal":
+        sm_family = sm.families.Gaussian()
+    elif family == "binomial":
+        sm_family = sm.families.Binomial()
+    elif family == "poisson":
+        sm_family = sm.families.Poisson()
+    else:
+        raise ValueError(family)
+    D = _design_for_statsmodels(X, mdl)
+    return sm.GLM(y, D, family=sm_family).fit(cov_type="HC0")
+
+
+def _eta_from_mu(family: str, mu: np.ndarray) -> np.ndarray:
+    if family == "normal":
+        return mu
+    if family == "binomial":
+        eps = np.finfo(float).eps
+        mc = np.clip(mu, eps, 1.0 - eps)
+        return np.log(mc / (1.0 - mc))
+    if family == "poisson":
+        return np.log(mu)
+    raise ValueError(family)
+
+
+@pytest.mark.parametrize("family", ["normal", "binomial", "poisson"])
+def test_robust_covariance_formula_matches_statsmodels_at_same_mu(
+    family: str,
+) -> None:
+    """Pin the sandwich formula independent of the optimizer.
+
+    gamdist's ADMM and statsmodels' IRLS converge to slightly different
+    points (eps_abs=1e-3 vs. machine precision), so a head-to-head
+    comparison of ``cov_params()`` mixes formula error with optimizer
+    error. Inject statsmodels' converged ``mu`` into gamdist and
+    verify the sandwich matches to numerical precision -- this is the
+    sharp test of correctness.
+    """
+    mdl, X, y = _gam_fit(family)
+    sm_res = _statsmodels_glm(family, X, y, mdl)
+
+    # Replace gamdist's converged eta with statsmodels' converged eta.
+    # robust_covariance reads mu via self._eval_inv_link(N * self.f_bar),
+    # so writing f_bar = eta_sm / N gives mu = mu_sm exactly.
+    D = _design_for_statsmodels(X, mdl)
+    eta_sm = sm_res.predict(D, which="linear")
+    mdl.f_bar = np.asarray(eta_sm, dtype=float) / mdl._num_features
+
+    V_gam = mdl.robust_covariance(cov_type="HC0")
+    V_sm = np.asarray(sm_res.cov_params())
+    assert V_gam.shape == V_sm.shape
+    np.testing.assert_allclose(V_gam, V_sm, rtol=1e-10, atol=1e-12)
+
+
+@pytest.mark.parametrize("family", ["normal", "binomial", "poisson"])
+def test_robust_covariance_end_to_end_close_to_statsmodels(family: str) -> None:
+    """End-to-end: fit with gamdist, compute sandwich, compare.
+
+    ADMM converges to ~1e-3 in primal/dual residuals, so the
+    fitted ``mu`` differs from statsmodels' MLE in roughly that
+    range, and the sandwich differs accordingly. We check looser
+    relative agreement; the tight pin on the formula is in the
+    test above.
+    """
+    mdl, X, y = _gam_fit(family)
+    sm_res = _statsmodels_glm(family, X, y, mdl)
+    V_gam = mdl.robust_covariance(cov_type="HC0")
+    V_sm = np.asarray(sm_res.cov_params())
+    np.testing.assert_allclose(V_gam, V_sm, rtol=5e-2, atol=5e-3)
+
+
+def test_robust_covariance_hc1_scales_hc0() -> None:
+    mdl, _, _ = _gam_fit("normal")
+    V0 = mdl.robust_covariance(cov_type="HC0")
+    V1 = mdl.robust_covariance(cov_type="HC1")
+    n = mdl._num_obs
+    p = V0.shape[0]
+    np.testing.assert_allclose(V1, V0 * (n / (n - p)), rtol=1e-12)
+
+
+def test_robust_covariance_design_matrix_layout() -> None:
+    mdl, X, _ = _gam_fit("normal")
+    D, names = mdl._design_matrix()
+    n = mdl._num_obs
+    # 1 intercept + 2 linear + (3 - 1) categorical = 5 columns
+    assert D.shape == (n, 5)
+    assert names[0] == "Intercept"
+    assert "x1" in names and "x2" in names
+    assert any("[T." in nm for nm in names)
+    # Intercept column is all ones.
+    np.testing.assert_array_equal(D[:, 0], np.ones(n))
+
+
+def test_robust_covariance_unfitted_raises() -> None:
+    mdl = GAM(family="normal")
+    mdl.add_feature(name="x1", type="linear")
+    with pytest.raises(AttributeError):
+        mdl.robust_covariance()
+
+
+def test_robust_covariance_rejects_unsupported_cov_type() -> None:
+    mdl, _, _ = _gam_fit("normal")
+    with pytest.raises(NotImplementedError):
+        mdl.robust_covariance(cov_type="HC3")
+
+
+def test_robust_covariance_rejects_spline_features() -> None:
+    rng = np.random.default_rng(0)
+    n = 200
+    x = rng.uniform(0, 1, size=n)
+    y = np.sin(2.0 * np.pi * x) + rng.normal(scale=0.1, size=n)
+    X = pd.DataFrame({"x": x})
+    mdl = GAM(family="normal")
+    mdl.add_feature(name="x", type="spline")
+    mdl.fit(X, y, max_its=80)
+    with pytest.raises(NotImplementedError):
+        mdl.robust_covariance()
+
+
+def test_robust_covariance_rejects_quantile_family() -> None:
+    rng = np.random.default_rng(1)
+    n = 300
+    x = rng.normal(size=n)
+    y = 1.0 + 2.0 * x + rng.normal(size=n)
+    X = pd.DataFrame({"x": x})
+    mdl = GAM(family="quantile", tau=0.5)
+    mdl.add_feature(name="x", type="linear")
+    mdl.fit(X, y, max_its=80)
+    with pytest.raises(NotImplementedError):
+        mdl.robust_covariance()


### PR DESCRIPTION
Adds GAM.robust_covariance(cov_type='HC0' | 'HC1') and a supporting
GAM._design_matrix(X=None) builder. Sandwich is the right inferential
tool for misspecified GLMs and for quasi-likelihood (issue #35), and
this is the foundational piece that work depends on.

The formula is pinned to numerical precision against statsmodels'
GLM(...).fit(cov_type='HC0').cov_params() by injecting statsmodels'
converged mu into gamdist's sandwich -- separating the formula
correctness from gamdist's ADMM tolerance. End-to-end fits agree at
the looser ~5e-2 level set by ADMM's eps_abs=eps_rel=1e-3.

Scope: linear + categorical features; normal/binomial/poisson/gamma/
inverse_gaussian families. Splines, covariate classes, weights, and
quantile/huber raise NotImplementedError up front and are tracked
for follow-on issues. Closes #34.