### PR TITLE
Implement L1 regularization for _LinearFeature (closes #53)

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,29 @@
+2026-04-26 : L1 regularization for linear features
+- _LinearFeature now accepts regularization={"l1": {"coef": lambda}}.
+  The previous option-B rejection (added in #20) is removed; the
+  matching error message in __init__ is replaced with the standard
+  "no coefficient" check used by the other regularizers.
+- The penalty lambda * |m| reduces the per-feature primal step to a
+  closed-form 1-D soft-threshold on b = x_centered^T y with threshold
+  lambda1 / rho. With ridge the elastic-net closed form drops out:
+      m = soft(b, lambda1/rho) / (xtx + 2*lambda2/rho).
+  When group_lasso is also active, its threshold (lambda_gl *
+  sqrt(xtx) / rho) adds to the L1 threshold -- both penalize |m| at
+  the origin and combine additively. No cvxpy on the linear path;
+  the existing ridge-only fast path is unchanged when L1 is off.
+- Smoothing scaling, save/load, and per-feature state plumbing for
+  L1 (_has_l1, _coef1, _lambda1) were already in place from the
+  pre-rejection era and are reused as-is.
+- Tests in tests/test_linear_l1.py cover: missing-coef error,
+  smoothing scaling, lambda=0 parity with the unpenalized solve,
+  huge-lambda zeroing the slope, intermediate-lambda shrinkage,
+  the soft-threshold closed form, the elastic-net closed form when
+  combined with l2, the additive-threshold closed form when combined
+  with group_lasso, save/load round-trip, and an end-to-end GAM test
+  where the noise feature shrinks to <10% of the signal feature's
+  norm. The rejection assertion in tests/test_linear_feature.py is
+  flipped to assert the missing-coef path instead. Closes #53.
+
 2026-04-26 : Reject non-convex (family, link) combinations up front
 - GAM.__init__ now validates (family, link) against an explicit
   SUPPORTED_FAMILY_LINK_PAIRS allow-list (the canonical pairs from

--- a/gamdist/linear_feature.py
+++ b/gamdist/linear_feature.py
@@ -55,15 +55,17 @@ class _LinearFeature(_Feature):
         transform : callable
             Transformation applied to the data (e.g. ``np.log1p``).
         regularization : dict
-            Description of regularization terms. ``l2`` (ridge) takes
-            ``{"coef": λ}`` and adds ``λ · m²`` to the objective.
-            ``group_lasso`` takes ``{"coef": λ}`` and adds
-            ``λ · ‖f_j‖₂ = λ · |m| · √(xᵀx)`` to the objective, which
-            zeros out the entire feature once ``λ`` is large enough.
-            The top-level ``prior`` key (if present) provides a scalar
-            prior estimate for the slope. ``l1`` is not yet implemented
-            for this feature type — see issue #53; for L1 today, use a
-            categorical feature.
+            Description of regularization terms. ``l1`` takes
+            ``{"coef": λ}`` and adds ``λ · |m|`` to the objective,
+            shrinking the slope toward zero with a closed-form 1-D
+            soft-threshold. ``l2`` (ridge) takes ``{"coef": λ}`` and
+            adds ``λ · m²`` to the objective. ``group_lasso`` takes
+            ``{"coef": λ}`` and adds ``λ · ‖f_j‖₂ = λ · |m| · √(xᵀx)``
+            to the objective, which zeros out the entire feature once
+            ``λ`` is large enough. ``l1`` and ``group_lasso`` combine
+            additively in the soft-threshold and stack with ``l2``
+            (elastic net). The top-level ``prior`` key (if present)
+            provides a scalar prior estimate for the slope.
         load_from_file : str
             If provided, restore parameters from this pickle path. All
             other parameters are ignored when loading.
@@ -100,11 +102,13 @@ class _LinearFeature(_Feature):
 
         if regularization is not None:
             if "l1" in regularization:
-                raise ValueError(
-                    "L1 regularization on linear features is not implemented "
-                    "(see issue #53). Use a categorical feature for L1 today, "
-                    "or restrict this feature's regularization to 'l2'."
-                )
+                self._has_l1 = True
+                if "coef" in regularization["l1"]:
+                    self._coef1 = float(regularization["l1"]["coef"])
+                else:
+                    raise ValueError(
+                        "No coefficient specified for l1 regularization term."
+                    )
 
             if "l2" in regularization:
                 self._has_l2 = True
@@ -291,11 +295,18 @@ class _LinearFeature(_Feature):
 
         b = float(self._x.dot(y))
 
+        # L1 (lambda1 * |m|) and group-lasso (lambda_gl * |m| * sqrt(xtx))
+        # both contribute additively to a 1-D soft-threshold on `b`. With
+        # ridge present, the shrinkage is the elastic-net closed form:
+        # m = sign(b) * max(|b| - threshold, 0) / denom, and m = 0 when
+        # |b| <= threshold.
+        threshold = 0.0
+        if self._has_l1:
+            threshold += self._lambda1 / rho
         if self._has_group_lasso:
-            # Group lasso on the per-feature contribution f_j = m * x_centered.
-            # ||f_j||_2 = |m| * sqrt(xtx), so the penalty contributes a
-            # 1-D soft-threshold on `b` with threshold lambda_gl/rho * sqrt(xtx).
-            threshold = self._lambda_group_lasso * math.sqrt(self._xtx) / rho
+            threshold += self._lambda_group_lasso * math.sqrt(self._xtx) / rho
+
+        if threshold > 0.0:
             if b > threshold:
                 self._m = (b - threshold) / denom
             elif b < -threshold:

--- a/tests/test_linear_feature.py
+++ b/tests/test_linear_feature.py
@@ -90,6 +90,6 @@ def test_dof_and_num_params() -> None:
     assert feat.dof() == 1.0
 
 
-def test_l1_regularization_rejected() -> None:
-    with pytest.raises(ValueError, match="L1 regularization on linear features"):
-        _LinearFeature(name="x", regularization={"l1": {"coef": 1.0}})
+def test_l1_regularization_no_coef_raises() -> None:
+    with pytest.raises(ValueError, match="No coefficient specified for l1"):
+        _LinearFeature(name="x", regularization={"l1": {}})

--- a/tests/test_linear_l1.py
+++ b/tests/test_linear_l1.py
@@ -1,0 +1,203 @@
+"""Tests for the l1 regularization on _LinearFeature.
+
+For a linear feature ``g(m) = lambda1 * |m|`` reduces the per-feature
+primal step to a 1-D soft-threshold on ``b = x_centeredᵀ y`` with
+threshold ``lambda1 / rho``. With ridge present, the closed form is
+the elastic net: ``m = soft(b, lambda1/rho) / (xtx + 2*lambda2/rho)``.
+With group_lasso also present, the L1 and group-lasso thresholds add.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from gamdist import GAM
+from gamdist.linear_feature import _LinearFeature
+
+
+def test_l1_smoothing_scales_lambda() -> None:
+    feat = _LinearFeature(name="x", regularization={"l1": {"coef": 0.4}})
+    feat.initialize(np.array([0.0, 1.0, 2.0, 3.0]), smoothing=2.5)
+    assert feat._has_l1
+    assert feat._lambda1 == pytest.approx(1.0)
+
+
+def test_l1_lambda_zero_matches_unpenalized() -> None:
+    rng = np.random.default_rng(0)
+    n = 200
+    x = rng.normal(size=n)
+    fpumz = rng.normal(size=n)
+
+    plain = _LinearFeature(name="x")
+    plain.initialize(x)
+    plain.optimize(fpumz, rho=1.0)
+
+    zero = _LinearFeature(name="x", regularization={"l1": {"coef": 0.0}})
+    zero.initialize(x)
+    zero.optimize(fpumz, rho=1.0)
+
+    assert zero._m == pytest.approx(plain._m, rel=1e-12, abs=1e-12)
+
+
+def test_l1_huge_lambda_zeros_slope() -> None:
+    rng = np.random.default_rng(0)
+    n = 200
+    x = rng.normal(size=n)
+    fpumz = rng.normal(size=n)
+    feat = _LinearFeature(name="x", regularization={"l1": {"coef": 1e6}})
+    feat.initialize(x)
+    feat.optimize(fpumz, rho=1.0)
+    assert feat._m == 0.0
+
+
+def test_l1_intermediate_lambda_shrinks() -> None:
+    rng = np.random.default_rng(0)
+    n = 200
+    x = rng.normal(size=n)
+    y = 2.0 * (x - x.mean()) + 0.1 * rng.normal(size=n)
+
+    unpenalized = _LinearFeature(name="x")
+    unpenalized.initialize(x)
+    unpenalized.optimize(-y, rho=1.0)
+
+    moderate = _LinearFeature(name="x", regularization={"l1": {"coef": 5.0}})
+    moderate.initialize(x)
+    moderate.optimize(-y, rho=1.0)
+
+    assert abs(moderate._m) < abs(unpenalized._m)
+    assert moderate._m != 0.0
+
+
+def test_l1_soft_threshold_closed_form() -> None:
+    rng = np.random.default_rng(7)
+    n = 50
+    x = rng.normal(size=n)
+    fpumz = rng.normal(size=n)
+    rho = 2.0
+    coef = 0.3
+
+    feat = _LinearFeature(name="x", regularization={"l1": {"coef": coef}})
+    feat.initialize(x)
+    feat.optimize(fpumz, rho=rho)
+
+    x_centered = x - x.mean()
+    xtx = float(x_centered.dot(x_centered))
+    b = float(x_centered.dot(-fpumz))
+    threshold = coef / rho
+    if abs(b) <= threshold:
+        expected = 0.0
+    else:
+        expected = np.sign(b) * (abs(b) - threshold) / xtx
+    assert feat._m == pytest.approx(expected, rel=1e-12, abs=1e-12)
+
+
+def test_l1_combined_with_l2_elastic_net_closed_form() -> None:
+    rng = np.random.default_rng(11)
+    n = 80
+    x = rng.normal(size=n)
+    fpumz = rng.normal(size=n)
+    rho = 3.0
+    coef1 = 0.6
+    coef2 = 1.5
+
+    feat = _LinearFeature(
+        name="x",
+        regularization={"l1": {"coef": coef1}, "l2": {"coef": coef2}},
+    )
+    feat.initialize(x)
+    feat.optimize(fpumz, rho=rho)
+
+    x_centered = x - x.mean()
+    xtx = float(x_centered.dot(x_centered))
+    b = float(x_centered.dot(-fpumz))
+    threshold = coef1 / rho
+    denom = xtx + 2.0 * coef2 / rho
+    if abs(b) <= threshold:
+        expected = 0.0
+    else:
+        expected = np.sign(b) * (abs(b) - threshold) / denom
+    assert feat._m == pytest.approx(expected, rel=1e-12, abs=1e-12)
+
+
+def test_l1_combined_with_group_lasso_thresholds_add() -> None:
+    rng = np.random.default_rng(13)
+    n = 60
+    x = rng.normal(size=n)
+    fpumz = rng.normal(size=n)
+    rho = 1.5
+    coef_l1 = 0.4
+    coef_gl = 0.7
+
+    feat = _LinearFeature(
+        name="x",
+        regularization={
+            "l1": {"coef": coef_l1},
+            "group_lasso": {"coef": coef_gl},
+        },
+    )
+    feat.initialize(x)
+    feat.optimize(fpumz, rho=rho)
+
+    x_centered = x - x.mean()
+    xtx = float(x_centered.dot(x_centered))
+    b = float(x_centered.dot(-fpumz))
+    threshold = coef_l1 / rho + coef_gl * np.sqrt(xtx) / rho
+    if abs(b) <= threshold:
+        expected = 0.0
+    else:
+        expected = np.sign(b) * (abs(b) - threshold) / xtx
+    assert feat._m == pytest.approx(expected, rel=1e-12, abs=1e-12)
+
+
+def test_l1_save_load_round_trip(tmp_path: Path) -> None:
+    feat = _LinearFeature(name="x", regularization={"l1": {"coef": 0.7}})
+    feat.initialize(
+        np.arange(5.0),
+        smoothing=2.0,
+        save_flag=True,
+        save_prefix=str(tmp_path / "model"),
+    )
+    feat._m = 1.25
+    feat._b = -0.5
+    feat._save()
+
+    restored = _LinearFeature(load_from_file=feat._filename)
+    assert restored._has_l1
+    assert restored._coef1 == pytest.approx(0.7)
+    assert restored._lambda1 == pytest.approx(1.4)
+    assert restored._m == pytest.approx(1.25)
+    assert restored._b == pytest.approx(-0.5)
+
+
+def test_l1_within_gam_drops_noise_feature() -> None:
+    # Two linear features. "signal" actually drives y; "noise" does not.
+    # With a moderate L1 applied to *both*, noise should shrink to (near)
+    # zero while signal retains meaningful slope.
+    rng = np.random.default_rng(2)
+    n = 400
+    signal = rng.normal(size=n)
+    noise = rng.normal(size=n)
+    y = 1.5 * (signal - signal.mean()) + 0.1 * rng.normal(size=n)
+    X = pd.DataFrame({"signal": signal, "noise": noise})
+
+    mdl = GAM(family="normal")
+    mdl.add_feature(
+        name="signal",
+        type="linear",
+        regularization={"l1": {"coef": 0.3}},
+    )
+    mdl.add_feature(
+        name="noise",
+        type="linear",
+        regularization={"l1": {"coef": 0.3}},
+    )
+    mdl.fit(X, y, max_its=60)
+
+    signal_feat = mdl._features["signal"]
+    noise_feat = mdl._features["noise"]
+    assert abs(signal_feat._m) > 0.5  # type: ignore[attr-defined]
+    assert abs(noise_feat._m) < 0.1 * abs(signal_feat._m)  # type: ignore[attr-defined]


### PR DESCRIPTION
Lifts the option-B rejection added in #20. L1 reduces the per-feature
primal step to a closed-form 1-D soft-threshold; combined with l2 it
gives the elastic-net shrinkage, and combined with group_lasso the
two thresholds add. No cvxpy on the linear path.