### PR TITLE
Add L_inf-norm group lasso variant (closes #45)

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,41 @@
+2026-04-26 : L_inf-norm group lasso variant
+- Added regularization={"group_lasso_inf": {"coef": lambda}} as a
+  drop-in companion to the existing L2 group lasso on _LinearFeature,
+  _CategoricalFeature, and _SplineFeature. The penalty is
+  lambda * ||f_j||_inf, where ||.||_inf is the largest absolute
+  per-row contribution in f_j. Convex by construction; produces a
+  different shrinkage geometry from the L2 variant -- coefficient
+  clipping rather than uniform contraction. Closes #45.
+- _LinearFeature: f_j = m * (x - mean(x)), so ||f_j||_inf =
+  |m| * max|x - mean(x)|. The penalty reduces to a 1-D
+  soft-threshold on the slope with threshold
+  lambda_inf * max|x - mean(x)| / rho. Stacks additively with the
+  existing L1 and L2-group-lasso thresholds and combines with
+  ridge as an elastic-net closed form (no cvxpy on the linear path).
+  initialize() now also stores _x_inf = max|x - mean(x)|; older
+  pickles recompute it on load.
+- _CategoricalFeature: penalty term
+  (2/rho) * lambda_inf * ||A q||_inf is added to the cvxpy program
+  alongside any other regularizers. ||A q||_inf = max_{c with obs}
+  |q_c|; categories that never appear in training data are masked
+  out (via ccs > 0) so unused-but-network-connected levels can't
+  inflate the penalty.
+- _SplineFeature: penalty term gamma_inf * cvx.norm_inf(N theta)
+  is added in _optimize_cvx alongside any L2 group-lasso term.
+  optimize() routes through the cvxpy path whenever either
+  group-lasso variant is active; the closed-form Cholesky path is
+  preserved when both are off.
+- Save/load round-trips updated for all three feature types; older
+  pickles default has_group_lasso_inf=False with zero coefficient.
+- gamdist.add_feature docstring mentions the new key. Tests in
+  tests/test_{linear,categorical,spline}_group_lasso_inf.py cover:
+  no-coef rejection, smoothing scaling, coef=0 matches unpenalized,
+  large-coef zeros the contribution, threshold/closed-form for the
+  linear path, the categorical clipping geometry vs. L2's uniform
+  contraction, additive combination with the L2 variant, save/load
+  round-trip, and end-to-end "drops the noise feature" within a
+  full GAM fit for each feature type.
+
 2026-04-26 : Quasi-likelihood families (quasi_poisson, quasi_binomial)
 - Added two new family aliases: family="quasi_poisson" routes to the
   Poisson log-link prox, and family="quasi_binomial" routes to the

--- a/gamdist/categorical_feature.py
+++ b/gamdist/categorical_feature.py
@@ -54,8 +54,12 @@ class _CategoricalFeature(_Feature):
             Name for feature, used to make plots.
         regularization : dict
             Description of regularization terms (``l1``, ``l2``,
-            ``group_lasso``, ``network_lasso``, ``network_ridge``).
-            See the package README for details.
+            ``group_lasso``, ``group_lasso_inf``, ``network_lasso``,
+            ``network_ridge``). The ``group_lasso_inf`` variant
+            penalizes ``λ · ‖A q‖_∞ = λ · max_{c with obs} |q_c|``,
+            which clips the largest per-level effect rather than the
+            uniform L2 contraction induced by ``group_lasso``. See
+            the package README for details.
         load_from_file : str
             Pickle path used to restore parameters. If specified,
             other parameters are ignored.
@@ -78,12 +82,14 @@ class _CategoricalFeature(_Feature):
         self._has_network_lasso = False
         self._has_network_ridge = False
         self._has_group_lasso = False
+        self._has_group_lasso_inf = False
         self._has_prior = False
         self._coef1: float | dict[Any, float] = 0.0
         self._coef2: float | dict[Any, float] = 0.0
         self._lambda_network_lasso: float = 0.0
         self._lambda_network_ridge: float = 0.0
         self._lambda_group_lasso: float = 0.0
+        self._lambda_group_lasso_inf: float = 0.0
         self._num_edges: int = 0
         self._num_edges_ridge: int = 0
         if regularization is not None:
@@ -162,6 +168,17 @@ class _CategoricalFeature(_Feature):
                 else:
                     raise ValueError(
                         "No coefficient specified for group_lasso regularization term."
+                    )
+
+            if "group_lasso_inf" in regularization:
+                self._has_group_lasso_inf = True
+                if "coef" in regularization["group_lasso_inf"]:
+                    self._lambda_group_lasso_inf = float(
+                        regularization["group_lasso_inf"]["coef"]
+                    )
+                else:
+                    raise ValueError(
+                        "No coefficient specified for group_lasso_inf regularization term."
                     )
 
             if (self._has_l1 or self._has_l2) and "prior" in regularization:
@@ -250,6 +267,9 @@ class _CategoricalFeature(_Feature):
         if self._has_group_lasso:
             self._lambda_group_lasso *= smoothing
 
+        if self._has_group_lasso_inf:
+            self._lambda_group_lasso_inf *= smoothing
+
         if (self._has_l1 or self._has_l2) and self._has_prior:
             prior_vec = np.zeros(self._num_categories)
             for key, value in self._prior.items():
@@ -319,6 +339,7 @@ class _CategoricalFeature(_Feature):
             "has_network_lasso": self._has_network_lasso,
             "has_network_ridge": self._has_network_ridge,
             "has_group_lasso": self._has_group_lasso,
+            "has_group_lasso_inf": self._has_group_lasso_inf,
             "has_prior": self._has_prior,
             "na_index": self._na_index,
             "x": self.x,
@@ -349,6 +370,8 @@ class _CategoricalFeature(_Feature):
             mv["lambda_network_ridge"] = self._lambda_network_ridge
         if self._has_group_lasso:
             mv["lambda_group_lasso"] = self._lambda_group_lasso
+        if self._has_group_lasso_inf:
+            mv["lambda_group_lasso_inf"] = self._lambda_group_lasso_inf
         if self._has_prior:
             mv["prior"] = self._prior
 
@@ -397,6 +420,12 @@ class _CategoricalFeature(_Feature):
             self._lambda_group_lasso = mv["lambda_group_lasso"]
         else:
             self._lambda_group_lasso = 0.0
+        # has_group_lasso_inf added later; default to False for older pickles.
+        self._has_group_lasso_inf = mv.get("has_group_lasso_inf", False)
+        if self._has_group_lasso_inf:
+            self._lambda_group_lasso_inf = mv["lambda_group_lasso_inf"]
+        else:
+            self._lambda_group_lasso_inf = 0.0
         self._has_prior = mv["has_prior"]
         if self._has_prior:
             self._prior = mv["prior"]
@@ -484,6 +513,18 @@ class _CategoricalFeature(_Feature):
             sqrt_ccs = cvx.Constant(np.sqrt(self._ccs))
             obj = obj + (2.0 / rho) * self._lambda_group_lasso * cvx.norm(
                 cvx.multiply(sqrt_ccs, q), 2
+            )
+
+        if self._has_group_lasso_inf:
+            # L_inf-norm group lasso variant: penalize ||A q||_inf =
+            # max_{c with obs} |q_c|. Because A is an indicator matrix,
+            # categories that never appear in the data don't contribute
+            # to ||f_j||_inf -- mask them out so a free-to-roam value at
+            # an unused level (e.g., one connected only by network_ridge
+            # edges) can't artificially saturate the penalty.
+            mask = cvx.Constant((self._ccs > 0).astype(float))
+            obj = obj + (2.0 / rho) * self._lambda_group_lasso_inf * cvx.norm_inf(
+                cvx.multiply(mask, q)
             )
 
         prob = cvx.Problem(cvx.Minimize(obj), constraints)

--- a/gamdist/gamdist.py
+++ b/gamdist/gamdist.py
@@ -680,8 +680,11 @@ class GAM:
              Splines always include a C2 smoothness penalty controlled via
              ``rel_dof``; ``regularization={"group_lasso": {"coef": λ}}``
              additionally shrinks the entire spline contribution and can
-             zero it out. Other features have more diverse options
-             described in their own documentation.
+             zero it out. ``group_lasso_inf`` is the L_∞-norm variant
+             (``λ · ‖f_j‖_∞``); it produces a clipping rather than a
+             uniform contraction and is also available on linear and
+             categorical features. Other features have more diverse
+             options described in their own documentation.
 
         Returns
         -------

--- a/gamdist/linear_feature.py
+++ b/gamdist/linear_feature.py
@@ -62,7 +62,13 @@ class _LinearFeature(_Feature):
             adds ``λ · m²`` to the objective. ``group_lasso`` takes
             ``{"coef": λ}`` and adds ``λ · ‖f_j‖₂ = λ · |m| · √(xᵀx)``
             to the objective, which zeros out the entire feature once
-            ``λ`` is large enough. ``l1`` and ``group_lasso`` combine
+            ``λ`` is large enough. ``group_lasso_inf`` takes
+            ``{"coef": λ}`` and adds ``λ · ‖f_j‖_∞ = λ · |m| ·
+            max|x - x̄|``, the L_∞-norm variant of the group lasso;
+            on a single-slope feature it has the same zero-the-slope
+            effect as the L2 group lasso, but the threshold scales
+            with the data range rather than its L2 norm. ``l1``,
+            ``group_lasso``, and ``group_lasso_inf`` all combine
             additively in the soft-threshold and stack with ``l2``
             (elastic net). The top-level ``prior`` key (if present)
             provides a scalar prior estimate for the slope.
@@ -91,6 +97,7 @@ class _LinearFeature(_Feature):
         self._has_l1 = False
         self._has_l2 = False
         self._has_group_lasso = False
+        self._has_group_lasso_inf = False
         self._has_prior = False
         self._coef1: float = 0.0
         self._coef2: float = 0.0
@@ -98,6 +105,8 @@ class _LinearFeature(_Feature):
         self._lambda2: float = 0.0
         self._coef_group_lasso: float = 0.0
         self._lambda_group_lasso: float = 0.0
+        self._coef_group_lasso_inf: float = 0.0
+        self._lambda_group_lasso_inf: float = 0.0
         self._prior: float = 0.0
 
         if regularization is not None:
@@ -128,6 +137,17 @@ class _LinearFeature(_Feature):
                 else:
                     raise ValueError(
                         "No coefficient specified for group_lasso regularization term."
+                    )
+
+            if "group_lasso_inf" in regularization:
+                self._has_group_lasso_inf = True
+                if "coef" in regularization["group_lasso_inf"]:
+                    self._coef_group_lasso_inf = float(
+                        regularization["group_lasso_inf"]["coef"]
+                    )
+                else:
+                    raise ValueError(
+                        "No coefficient specified for group_lasso_inf regularization term."
                     )
 
             if self._has_l1 or self._has_l2:
@@ -173,6 +193,7 @@ class _LinearFeature(_Feature):
             self._x = xa - self._xmean
 
         self._xtx: float = float(self._x.dot(self._x))
+        self._x_inf: float = float(np.max(np.abs(self._x))) if self._x.size else 0.0
         self._m: float = 0.0
         self._b: float = 0.0
 
@@ -182,6 +203,8 @@ class _LinearFeature(_Feature):
             self._lambda2 = self._coef2 * smoothing
         if self._has_group_lasso:
             self._lambda_group_lasso = self._coef_group_lasso * smoothing
+        if self._has_group_lasso_inf:
+            self._lambda_group_lasso_inf = self._coef_group_lasso_inf * smoothing
 
         self._verbose = verbose
         if save_flag:
@@ -203,6 +226,7 @@ class _LinearFeature(_Feature):
             "has_l1": self._has_l1,
             "has_l2": self._has_l2,
             "has_group_lasso": self._has_group_lasso,
+            "has_group_lasso_inf": self._has_group_lasso_inf,
             "has_prior": self._has_prior,
             "verbose": self._verbose,
             "name": self._name,
@@ -210,6 +234,7 @@ class _LinearFeature(_Feature):
             "xmean": self._xmean,
             "x": self._x,
             "xtx": self._xtx,
+            "x_inf": self._x_inf,
             "m": self._m,
             "b": self._b,
         }
@@ -224,6 +249,9 @@ class _LinearFeature(_Feature):
         if self._has_group_lasso:
             mv["coef_group_lasso"] = self._coef_group_lasso
             mv["lambda_group_lasso"] = self._lambda_group_lasso
+        if self._has_group_lasso_inf:
+            mv["coef_group_lasso_inf"] = self._coef_group_lasso_inf
+            mv["lambda_group_lasso_inf"] = self._lambda_group_lasso_inf
         if self._has_prior:
             mv["prior"] = self._prior
 
@@ -257,6 +285,14 @@ class _LinearFeature(_Feature):
         else:
             self._coef_group_lasso = 0.0
             self._lambda_group_lasso = 0.0
+        # has_group_lasso_inf added later; default to False for older pickles.
+        self._has_group_lasso_inf = mv.get("has_group_lasso_inf", False)
+        if self._has_group_lasso_inf:
+            self._coef_group_lasso_inf = mv["coef_group_lasso_inf"]
+            self._lambda_group_lasso_inf = mv["lambda_group_lasso_inf"]
+        else:
+            self._coef_group_lasso_inf = 0.0
+            self._lambda_group_lasso_inf = 0.0
         self._has_prior = mv["has_prior"]
         if self._has_prior:
             self._prior = mv["prior"]
@@ -268,6 +304,11 @@ class _LinearFeature(_Feature):
         self._xmean = mv["xmean"]
         self._x = mv["x"]
         self._xtx = mv["xtx"]
+        # x_inf added alongside group_lasso_inf; recover for older pickles.
+        if "x_inf" in mv:
+            self._x_inf = mv["x_inf"]
+        else:
+            self._x_inf = float(np.max(np.abs(self._x))) if self._x.size else 0.0
         self._m = mv["m"]
         self._b = mv["b"]
 
@@ -295,9 +336,11 @@ class _LinearFeature(_Feature):
 
         b = float(self._x.dot(y))
 
-        # L1 (lambda1 * |m|) and group-lasso (lambda_gl * |m| * sqrt(xtx))
-        # both contribute additively to a 1-D soft-threshold on `b`. With
-        # ridge present, the shrinkage is the elastic-net closed form:
+        # L1 (lambda1 * |m|), L2 group lasso (lambda_gl * |m| * sqrt(xtx)),
+        # and L_inf group lasso (lambda_gl_inf * |m| * max|x - xmean|) all
+        # contribute additively to a 1-D soft-threshold on `b` -- they are
+        # each a positive multiple of |m|. With ridge present, the
+        # shrinkage is the elastic-net closed form:
         # m = sign(b) * max(|b| - threshold, 0) / denom, and m = 0 when
         # |b| <= threshold.
         threshold = 0.0
@@ -305,6 +348,8 @@ class _LinearFeature(_Feature):
             threshold += self._lambda1 / rho
         if self._has_group_lasso:
             threshold += self._lambda_group_lasso * math.sqrt(self._xtx) / rho
+        if self._has_group_lasso_inf:
+            threshold += self._lambda_group_lasso_inf * self._x_inf / rho
 
         if threshold > 0.0:
             if b > threshold:

--- a/gamdist/spline_feature.py
+++ b/gamdist/spline_feature.py
@@ -200,10 +200,13 @@ class _SplineFeature(_Feature):
             Relative degrees of freedom for the curvature smoother.
         regularization : dict
             Optional extra regularization beyond the built-in curvature
-            penalty. Currently only ``group_lasso`` is supported, taking
-            ``{"coef": λ}``: it adds ``λ · ‖N θ‖₂`` to the objective,
-            zeroing out the entire spline contribution once λ is large
-            enough.
+            penalty. ``group_lasso`` takes ``{"coef": λ}`` and adds
+            ``λ · ‖N θ‖₂`` to the objective, zeroing out the entire
+            spline contribution once λ is large enough. ``group_lasso_inf``
+            takes ``{"coef": λ}`` and adds ``λ · ‖N θ‖_∞`` -- the L_∞
+            variant clips the largest pointwise contribution rather than
+            applying uniform L2 contraction. The two variants combine
+            additively when both are specified.
         load_from_file : str
             If provided, restore parameters from this pickle path. All
             other parameters are ignored when loading.
@@ -231,6 +234,9 @@ class _SplineFeature(_Feature):
         self._has_group_lasso = False
         self._coef_group_lasso: float = 0.0
         self._lambda_group_lasso: float = 0.0
+        self._has_group_lasso_inf = False
+        self._coef_group_lasso_inf: float = 0.0
+        self._lambda_group_lasso_inf: float = 0.0
         self._solver = "CLARABEL"
         if regularization is not None and "group_lasso" in regularization:
             self._has_group_lasso = True
@@ -239,6 +245,17 @@ class _SplineFeature(_Feature):
             else:
                 raise ValueError(
                     "No coefficient specified for group_lasso regularization term."
+                )
+
+        if regularization is not None and "group_lasso_inf" in regularization:
+            self._has_group_lasso_inf = True
+            if "coef" in regularization["group_lasso_inf"]:
+                self._coef_group_lasso_inf = float(
+                    regularization["group_lasso_inf"]["coef"]
+                )
+            else:
+                raise ValueError(
+                    "No coefficient specified for group_lasso_inf regularization term."
                 )
 
     def initialize(
@@ -290,6 +307,9 @@ class _SplineFeature(_Feature):
         if self._has_group_lasso:
             self._lambda_group_lasso = self._coef_group_lasso * smoothing
 
+        if self._has_group_lasso_inf:
+            self._lambda_group_lasso_inf = self._coef_group_lasso_inf * smoothing
+
         if save_flag:
             self._save_self = True
             if save_prefix is None:
@@ -323,6 +343,7 @@ class _SplineFeature(_Feature):
             "dof": self._dof,
             "save_self": self._save_self,
             "has_group_lasso": self._has_group_lasso,
+            "has_group_lasso_inf": self._has_group_lasso_inf,
             "solver": self._solver,
         }
         if self._has_transform:
@@ -330,6 +351,9 @@ class _SplineFeature(_Feature):
         if self._has_group_lasso:
             mv["coef_group_lasso"] = self._coef_group_lasso
             mv["lambda_group_lasso"] = self._lambda_group_lasso
+        if self._has_group_lasso_inf:
+            mv["coef_group_lasso_inf"] = self._coef_group_lasso_inf
+            mv["lambda_group_lasso_inf"] = self._lambda_group_lasso_inf
 
         with open(self._filename, "wb") as f:
             pickle.dump(mv, f)
@@ -371,6 +395,14 @@ class _SplineFeature(_Feature):
         else:
             self._coef_group_lasso = 0.0
             self._lambda_group_lasso = 0.0
+        # has_group_lasso_inf added later; default for older pickles.
+        self._has_group_lasso_inf = mv.get("has_group_lasso_inf", False)
+        if self._has_group_lasso_inf:
+            self._coef_group_lasso_inf = mv["coef_group_lasso_inf"]
+            self._lambda_group_lasso_inf = mv["lambda_group_lasso_inf"]
+        else:
+            self._coef_group_lasso_inf = 0.0
+            self._lambda_group_lasso_inf = 0.0
 
     def optimize(self, fpumz: FloatArray, rho: float) -> FloatArray:
         """Solve the per-feature primal step.
@@ -387,7 +419,7 @@ class _SplineFeature(_Feature):
         fkp1 : (m,) ndarray
             Vector representing this feature's contribution to the response.
         """
-        if self._has_group_lasso:
+        if self._has_group_lasso or self._has_group_lasso_inf:
             self._theta = self._optimize_cvx(fpumz, rho)
         else:
             self._theta = self._optimize_chol(fpumz, rho)
@@ -418,25 +450,29 @@ class _SplineFeature(_Feature):
         """Primal step via cvxpy when a group_lasso term is present.
 
         Group lasso on the per-feature contribution f_j = N theta penalizes
-        ``λ · ||N θ||₂``, which is non-smooth at zero and breaks the
-        closed-form Cholesky path. The fast path is used whenever group
-        lasso is off, so this branch only runs when needed.
+        ``λ · ||N θ||₂`` (or ``λ · ||N θ||_∞`` for the L_inf variant), both
+        of which are non-smooth at zero and break the closed-form Cholesky
+        path. The fast path is used whenever neither variant is active, so
+        this branch only runs when needed.
         """
         target = self._N.dot(self._theta) - fpumz
         K = len(self._theta)
         nu = 2.0 * self._smoothing * self._lmbda / rho
         gamma = 2.0 * self._lambda_group_lasso / rho
+        gamma_inf = 2.0 * self._lambda_group_lasso_inf / rho
 
         theta_var = cvx.Variable(K)
         N_const = cvx.Constant(self._N)
         Omega_const = cvx.psd_wrap(cvx.Constant(self._Omega))
         c_vec = np.mean(self._N, axis=0)
 
-        obj = (
-            cvx.sum_squares(N_const @ theta_var - cvx.Constant(target))
-            + nu * cvx.quad_form(theta_var, Omega_const)
-            + gamma * cvx.norm(N_const @ theta_var, 2)
-        )
+        obj: Any = cvx.sum_squares(
+            N_const @ theta_var - cvx.Constant(target)
+        ) + nu * cvx.quad_form(theta_var, Omega_const)
+        if self._has_group_lasso:
+            obj = obj + gamma * cvx.norm(N_const @ theta_var, 2)
+        if self._has_group_lasso_inf:
+            obj = obj + gamma_inf * cvx.norm_inf(N_const @ theta_var)
         constraints = [cvx.Constant(c_vec) @ theta_var == 0]
         prob = cvx.Problem(cvx.Minimize(obj), constraints)
         # cvxpy's "Solution may be inaccurate" UserWarning escapes the

--- a/tests/test_categorical_group_lasso_inf.py
+++ b/tests/test_categorical_group_lasso_inf.py
@@ -1,0 +1,190 @@
+"""Tests for the ``group_lasso_inf`` regularization on _CategoricalFeature.
+
+The L_inf-norm group lasso penalizes ``λ · ||A q||_inf = λ · max_c |q_c|``
+(restricted to categories that actually appear in the data). It clips the
+largest per-level effect rather than the uniform L2 contraction induced by
+the standard group lasso, so the resulting shrinkage geometry is different.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from gamdist import GAM
+from gamdist.categorical_feature import _CategoricalFeature
+
+
+def test_group_lasso_inf_no_coef_raises() -> None:
+    with pytest.raises(
+        ValueError, match="No coefficient specified for group_lasso_inf"
+    ):
+        _CategoricalFeature(name="g", regularization={"group_lasso_inf": {}})
+
+
+def test_group_lasso_inf_smoothing_scales_lambda() -> None:
+    feat = _CategoricalFeature(
+        name="g", regularization={"group_lasso_inf": {"coef": 0.4}}
+    )
+    feat.initialize(np.array(["a", "b", "a"]), smoothing=2.5)
+    assert feat._has_group_lasso_inf
+    assert feat._lambda_group_lasso_inf == pytest.approx(1.0)
+
+
+def test_group_lasso_inf_lambda_zero_matches_unpenalized() -> None:
+    rng = np.random.default_rng(0)
+    x = rng.choice(np.array(["a", "b", "c"]), size=200)
+    fpumz = rng.normal(size=200)
+
+    plain = _CategoricalFeature(name="g")
+    plain.initialize(x)
+    plain.optimize(fpumz, rho=1.0)
+
+    zero = _CategoricalFeature(
+        name="g", regularization={"group_lasso_inf": {"coef": 0.0}}
+    )
+    zero.initialize(x)
+    zero.optimize(fpumz, rho=1.0)
+
+    np.testing.assert_allclose(zero.p, plain.p, atol=1e-6)
+
+
+def test_group_lasso_inf_huge_lambda_zeros_parameters() -> None:
+    rng = np.random.default_rng(0)
+    x = rng.choice(np.array(["a", "b", "c"]), size=200)
+    fpumz = rng.normal(size=200)
+    feat = _CategoricalFeature(
+        name="g", regularization={"group_lasso_inf": {"coef": 1e6}}
+    )
+    feat.initialize(x)
+    feat.optimize(fpumz, rho=1.0)
+    np.testing.assert_allclose(feat.p, 0.0, atol=1e-6)
+
+
+def test_group_lasso_inf_clips_max_level() -> None:
+    # Different shrinkage geometries: the L2 group lasso shrinks every
+    # level roughly proportionally, while the L_inf variant clips only
+    # the largest |q_c| and leaves the smaller levels close to their
+    # unpenalized values. Construct fpumz so that one category has a
+    # much larger unpenalized estimate than the others, then verify
+    # both effects on the same data.
+    rng = np.random.default_rng(11)
+    n = 600
+    cats = np.array(["a", "b", "c"])
+    x = rng.choice(cats, size=n)
+    fpumz = rng.normal(size=n) * 0.1
+    fpumz[x == "a"] -= 3.0  # Inflate category "a"'s unpenalized effect.
+
+    unpen = _CategoricalFeature(name="g")
+    unpen.initialize(x)
+    unpen.optimize(fpumz, rho=1.0)
+
+    coef = 5.0
+    linf = _CategoricalFeature(
+        name="g", regularization={"group_lasso_inf": {"coef": coef}}
+    )
+    linf.initialize(x)
+    linf.optimize(fpumz, rho=1.0)
+
+    l2 = _CategoricalFeature(name="g", regularization={"group_lasso": {"coef": coef}})
+    l2.initialize(x)
+    l2.optimize(fpumz, rho=1.0)
+
+    # L_inf reduces the maximum |q_c| relative to the unpenalized fit.
+    assert np.max(np.abs(linf.p)) < np.max(np.abs(unpen.p))
+
+    # Smaller-level effects are preserved more under L_inf than under L2.
+    # Identify the non-extremal levels by ordering on |unpen.p|.
+    order = np.argsort(np.abs(unpen.p))
+    smaller = order[:-1]
+    # Sum of |delta| from unpenalized over the non-max levels: L2 moves
+    # them noticeably, L_inf barely touches them.
+    l2_smaller_drift = float(np.sum(np.abs(l2.p[smaller] - unpen.p[smaller])))
+    linf_smaller_drift = float(np.sum(np.abs(linf.p[smaller] - unpen.p[smaller])))
+    assert linf_smaller_drift < l2_smaller_drift
+
+
+def test_group_lasso_inf_combines_with_l2_variant() -> None:
+    # Verify that having both variants on simultaneously runs to a valid
+    # optimum and shrinks at least as much as either alone.
+    rng = np.random.default_rng(4)
+    x = rng.choice(np.array(["a", "b", "c", "d"]), size=300)
+    fpumz = rng.normal(size=300)
+
+    only_l2 = _CategoricalFeature(
+        name="g", regularization={"group_lasso": {"coef": 0.5}}
+    )
+    only_l2.initialize(x)
+    only_l2.optimize(fpumz, rho=1.0)
+
+    only_linf = _CategoricalFeature(
+        name="g", regularization={"group_lasso_inf": {"coef": 0.5}}
+    )
+    only_linf.initialize(x)
+    only_linf.optimize(fpumz, rho=1.0)
+
+    both = _CategoricalFeature(
+        name="g",
+        regularization={
+            "group_lasso": {"coef": 0.5},
+            "group_lasso_inf": {"coef": 0.5},
+        },
+    )
+    both.initialize(x)
+    both.optimize(fpumz, rho=1.0)
+
+    # Stacking shrinks at least as hard as either alone (in both norms).
+    assert np.linalg.norm(both.p) <= np.linalg.norm(only_l2.p) + 1e-6
+    assert np.max(np.abs(both.p)) <= np.max(np.abs(only_linf.p)) + 1e-6
+
+
+def test_group_lasso_inf_save_load_round_trip(tmp_path: Path) -> None:
+    feat = _CategoricalFeature(
+        name="g", regularization={"group_lasso_inf": {"coef": 0.7}}
+    )
+    feat.initialize(
+        np.array(["a", "b", "a"]),
+        smoothing=2.0,
+        save_flag=True,
+        save_prefix=str(tmp_path / "model"),
+    )
+    feat.p = np.array([0.3, -0.3])
+    feat._save()
+
+    restored = _CategoricalFeature(load_from_file=feat._filename)
+    assert restored._has_group_lasso_inf
+    assert restored._lambda_group_lasso_inf == pytest.approx(1.4)
+    np.testing.assert_allclose(restored.p, feat.p)
+
+
+def test_group_lasso_inf_within_gam_drops_noise_feature() -> None:
+    rng = np.random.default_rng(2)
+    n = 400
+    signal = rng.choice(np.array(["a", "b", "c"]), size=n)
+    noise = rng.choice(np.array(["x", "y", "z"]), size=n)
+    signal_effects = {"a": 1.5, "b": -1.0, "c": -0.5}
+    y = np.array([signal_effects[s] for s in signal]) + rng.normal(size=n) * 0.1
+    X = pd.DataFrame({"signal": signal, "noise": noise})
+
+    mdl = GAM(family="normal")
+    mdl.add_feature(
+        name="signal",
+        type="categorical",
+        regularization={"group_lasso_inf": {"coef": 0.3}},
+    )
+    mdl.add_feature(
+        name="noise",
+        type="categorical",
+        regularization={"group_lasso_inf": {"coef": 0.3}},
+    )
+    mdl.fit(X, y, max_its=40)
+
+    signal_feat = mdl._features["signal"]
+    noise_feat = mdl._features["noise"]
+    signal_norm = float(np.linalg.norm(signal_feat.p))  # type: ignore[attr-defined]
+    noise_norm = float(np.linalg.norm(noise_feat.p))  # type: ignore[attr-defined]
+    assert signal_norm > 0.5
+    assert noise_norm < 0.2 * signal_norm

--- a/tests/test_linear_group_lasso_inf.py
+++ b/tests/test_linear_group_lasso_inf.py
@@ -1,0 +1,194 @@
+"""Tests for the ``group_lasso_inf`` regularization on _LinearFeature.
+
+For a linear feature the per-feature contribution vector is
+``f_j = m * (x - mean(x))``. ``||f_j||_inf = |m| * max|x - mean(x)|``,
+so the L_inf group-lasso penalty also reduces to a 1-D soft-threshold
+on the slope. The threshold scales with ``max|x - mean(x)|`` rather
+than ``sqrt(xtx)``, so for the same coefficient it shrinks differently
+than the L2 variant.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from gamdist import GAM
+from gamdist.linear_feature import _LinearFeature
+
+
+def test_group_lasso_inf_no_coef_raises() -> None:
+    with pytest.raises(
+        ValueError, match="No coefficient specified for group_lasso_inf"
+    ):
+        _LinearFeature(name="x", regularization={"group_lasso_inf": {}})
+
+
+def test_group_lasso_inf_smoothing_scales_lambda() -> None:
+    feat = _LinearFeature(name="x", regularization={"group_lasso_inf": {"coef": 0.4}})
+    feat.initialize(np.array([0.0, 1.0, 2.0, 3.0]), smoothing=2.5)
+    assert feat._has_group_lasso_inf
+    assert feat._lambda_group_lasso_inf == pytest.approx(1.0)
+
+
+def test_group_lasso_inf_lambda_zero_matches_unpenalized() -> None:
+    rng = np.random.default_rng(0)
+    n = 200
+    x = rng.normal(size=n)
+    fpumz = rng.normal(size=n)
+
+    plain = _LinearFeature(name="x")
+    plain.initialize(x)
+    plain.optimize(fpumz, rho=1.0)
+
+    zero = _LinearFeature(name="x", regularization={"group_lasso_inf": {"coef": 0.0}})
+    zero.initialize(x)
+    zero.optimize(fpumz, rho=1.0)
+
+    assert zero._m == pytest.approx(plain._m, rel=1e-12, abs=1e-12)
+
+
+def test_group_lasso_inf_huge_lambda_zeros_slope() -> None:
+    rng = np.random.default_rng(0)
+    n = 200
+    x = rng.normal(size=n)
+    fpumz = rng.normal(size=n)
+    feat = _LinearFeature(name="x", regularization={"group_lasso_inf": {"coef": 1e6}})
+    feat.initialize(x)
+    feat.optimize(fpumz, rho=1.0)
+    assert feat._m == 0.0
+
+
+def test_group_lasso_inf_soft_threshold_closed_form() -> None:
+    # The L_inf group lasso on a linear feature reduces to soft-thresholding
+    # the slope with threshold ``coef * max|x - mean(x)| / rho``.
+    rng = np.random.default_rng(7)
+    n = 50
+    x = rng.normal(size=n)
+    fpumz = rng.normal(size=n)
+    rho = 2.0
+    coef = 0.3
+
+    feat = _LinearFeature(name="x", regularization={"group_lasso_inf": {"coef": coef}})
+    feat.initialize(x)
+    feat.optimize(fpumz, rho=rho)
+
+    x_centered = x - x.mean()
+    xtx = float(x_centered.dot(x_centered))
+    x_inf = float(np.max(np.abs(x_centered)))
+    b = float(x_centered.dot(-fpumz))
+    threshold = coef * x_inf / rho
+    if abs(b) <= threshold:
+        expected = 0.0
+    else:
+        expected = np.sign(b) * (abs(b) - threshold) / xtx
+    assert feat._m == pytest.approx(expected, rel=1e-12, abs=1e-12)
+
+
+def test_group_lasso_inf_threshold_differs_from_l2() -> None:
+    # On the same data, the L2 and L_inf group-lasso variants produce
+    # different effective thresholds (sqrt(xtx) vs max|x - mean(x)|).
+    # For an iid-normal feature with n=200, sqrt(xtx) ~ sqrt(n) >> max|x|
+    # so the L2 variant shrinks the slope more aggressively at equal coef.
+    rng = np.random.default_rng(1)
+    n = 200
+    x = rng.normal(size=n)
+    y = 2.0 * (x - x.mean()) + 0.1 * rng.normal(size=n)
+    coef = 1.5
+
+    l2 = _LinearFeature(name="x", regularization={"group_lasso": {"coef": coef}})
+    l2.initialize(x)
+    l2.optimize(-y, rho=1.0)
+
+    linf = _LinearFeature(name="x", regularization={"group_lasso_inf": {"coef": coef}})
+    linf.initialize(x)
+    linf.optimize(-y, rho=1.0)
+
+    x_centered = x - x.mean()
+    assert np.sqrt(x_centered.dot(x_centered)) > np.max(np.abs(x_centered))
+    # Same sign, different magnitudes; L2 threshold is bigger so it pulls
+    # the slope closer to zero.
+    assert abs(l2._m) < abs(linf._m)
+
+
+def test_group_lasso_inf_combines_with_l2_variant() -> None:
+    # The two variants stack additively in the soft-threshold.
+    rng = np.random.default_rng(3)
+    n = 100
+    x = rng.normal(size=n)
+    fpumz = rng.normal(size=n)
+    rho = 1.0
+    coef_l2 = 0.2
+    coef_linf = 0.5
+
+    feat = _LinearFeature(
+        name="x",
+        regularization={
+            "group_lasso": {"coef": coef_l2},
+            "group_lasso_inf": {"coef": coef_linf},
+        },
+    )
+    feat.initialize(x)
+    feat.optimize(fpumz, rho=rho)
+
+    x_centered = x - x.mean()
+    xtx = float(x_centered.dot(x_centered))
+    x_inf = float(np.max(np.abs(x_centered)))
+    b = float(x_centered.dot(-fpumz))
+    threshold = (coef_l2 * np.sqrt(xtx) + coef_linf * x_inf) / rho
+    if abs(b) <= threshold:
+        expected = 0.0
+    else:
+        expected = np.sign(b) * (abs(b) - threshold) / xtx
+    assert feat._m == pytest.approx(expected, rel=1e-12, abs=1e-12)
+
+
+def test_group_lasso_inf_save_load_round_trip(tmp_path: Path) -> None:
+    feat = _LinearFeature(name="x", regularization={"group_lasso_inf": {"coef": 0.7}})
+    feat.initialize(
+        np.arange(5.0),
+        smoothing=2.0,
+        save_flag=True,
+        save_prefix=str(tmp_path / "model"),
+    )
+    feat._m = 1.25
+    feat._b = -0.5
+    feat._save()
+
+    restored = _LinearFeature(load_from_file=feat._filename)
+    assert restored._has_group_lasso_inf
+    assert restored._coef_group_lasso_inf == pytest.approx(0.7)
+    assert restored._lambda_group_lasso_inf == pytest.approx(1.4)
+    assert restored._x_inf == pytest.approx(feat._x_inf)
+    assert restored._m == pytest.approx(1.25)
+    assert restored._b == pytest.approx(-0.5)
+
+
+def test_group_lasso_inf_within_gam_drops_noise_feature() -> None:
+    rng = np.random.default_rng(2)
+    n = 400
+    signal = rng.normal(size=n)
+    noise = rng.normal(size=n)
+    y = 1.5 * (signal - signal.mean()) + 0.1 * rng.normal(size=n)
+    X = pd.DataFrame({"signal": signal, "noise": noise})
+
+    mdl = GAM(family="normal")
+    mdl.add_feature(
+        name="signal",
+        type="linear",
+        regularization={"group_lasso_inf": {"coef": 0.8}},
+    )
+    mdl.add_feature(
+        name="noise",
+        type="linear",
+        regularization={"group_lasso_inf": {"coef": 0.8}},
+    )
+    mdl.fit(X, y, max_its=60)
+
+    signal_feat = mdl._features["signal"]
+    noise_feat = mdl._features["noise"]
+    assert abs(signal_feat._m) > 0.5  # type: ignore[attr-defined]
+    assert abs(noise_feat._m) < 0.1 * abs(signal_feat._m)  # type: ignore[attr-defined]

--- a/tests/test_spline_group_lasso_inf.py
+++ b/tests/test_spline_group_lasso_inf.py
@@ -1,0 +1,187 @@
+"""Tests for the ``group_lasso_inf`` regularization on _SplineFeature.
+
+For a spline feature the per-feature contribution vector is
+``f_j = N θ``. The L_inf-norm group-lasso penalty ``λ · ||N θ||_inf``
+clips the largest pointwise contribution rather than uniformly
+contracting the whole curve. The closed-form Cholesky path is bypassed
+in favor of the cvxpy path whenever this term is active.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from gamdist import GAM
+from gamdist.spline_feature import _SplineFeature
+
+
+def test_group_lasso_inf_no_coef_raises() -> None:
+    with pytest.raises(
+        ValueError, match="No coefficient specified for group_lasso_inf"
+    ):
+        _SplineFeature(name="x", regularization={"group_lasso_inf": {}})
+
+
+def test_group_lasso_inf_smoothing_scales_lambda() -> None:
+    feat = _SplineFeature(name="x", regularization={"group_lasso_inf": {"coef": 0.4}})
+    feat.initialize(np.linspace(0.0, 1.0, 50), smoothing=2.5)
+    assert feat._has_group_lasso_inf
+    assert feat._lambda_group_lasso_inf == pytest.approx(1.0)
+
+
+def test_group_lasso_inf_lambda_zero_matches_unpenalized() -> None:
+    rng = np.random.default_rng(0)
+    n = 200
+    x = rng.uniform(0.0, 1.0, size=n)
+    y = np.sin(2 * np.pi * x)
+    y = y - y.mean()
+
+    plain = _SplineFeature(name="x", rel_dof=6.0)
+    plain.initialize(x)
+    plain.optimize(-y, rho=1.0)
+    plain_pred = plain._N.dot(plain._theta)
+
+    zero = _SplineFeature(
+        name="x", rel_dof=6.0, regularization={"group_lasso_inf": {"coef": 0.0}}
+    )
+    zero.initialize(x)
+    zero.optimize(-y, rho=1.0)
+    zero_pred = zero._N.dot(zero._theta)
+
+    np.testing.assert_allclose(zero_pred, plain_pred, atol=1e-6)
+
+
+def test_group_lasso_inf_huge_lambda_zeros_contribution() -> None:
+    rng = np.random.default_rng(0)
+    n = 200
+    x = rng.uniform(0.0, 1.0, size=n)
+    y = np.sin(2 * np.pi * x)
+    y = y - y.mean()
+    feat = _SplineFeature(
+        name="x", rel_dof=6.0, regularization={"group_lasso_inf": {"coef": 1e3}}
+    )
+    feat.initialize(x)
+    feat.optimize(-y, rho=1.0)
+    pred = feat.predict(x)
+    np.testing.assert_allclose(pred, 0.0, atol=1e-3)
+
+
+def test_group_lasso_inf_intermediate_lambda_shrinks() -> None:
+    rng = np.random.default_rng(0)
+    n = 200
+    x = rng.uniform(0.0, 1.0, size=n)
+    y = 3.0 * np.sin(2 * np.pi * x)
+    y = y - y.mean()
+
+    unpenalized = _SplineFeature(name="x", rel_dof=6.0)
+    unpenalized.initialize(x)
+    unpenalized.optimize(-y, rho=1.0)
+
+    moderate = _SplineFeature(
+        name="x", rel_dof=6.0, regularization={"group_lasso_inf": {"coef": 1.0}}
+    )
+    moderate.initialize(x)
+    moderate.optimize(-y, rho=1.0)
+
+    # Both the L_inf norm and the L2 norm of the contribution shrink.
+    assert np.max(np.abs(moderate.predict(x))) < np.max(np.abs(unpenalized.predict(x)))
+    assert np.linalg.norm(moderate.predict(x)) < np.linalg.norm(unpenalized.predict(x))
+
+
+def test_group_lasso_inf_combines_with_l2_variant() -> None:
+    # Both variants on simultaneously: the optimization should still
+    # converge and shrink the contribution at least as much (in both
+    # norms) as either alone.
+    rng = np.random.default_rng(3)
+    n = 200
+    x = rng.uniform(0.0, 1.0, size=n)
+    y = 2.0 * np.sin(2 * np.pi * x)
+    y = y - y.mean()
+
+    only_l2 = _SplineFeature(
+        name="x", rel_dof=6.0, regularization={"group_lasso": {"coef": 0.5}}
+    )
+    only_l2.initialize(x)
+    only_l2.optimize(-y, rho=1.0)
+
+    only_linf = _SplineFeature(
+        name="x", rel_dof=6.0, regularization={"group_lasso_inf": {"coef": 0.5}}
+    )
+    only_linf.initialize(x)
+    only_linf.optimize(-y, rho=1.0)
+
+    both = _SplineFeature(
+        name="x",
+        rel_dof=6.0,
+        regularization={
+            "group_lasso": {"coef": 0.5},
+            "group_lasso_inf": {"coef": 0.5},
+        },
+    )
+    both.initialize(x)
+    both.optimize(-y, rho=1.0)
+
+    assert np.linalg.norm(both.predict(x)) <= np.linalg.norm(only_l2.predict(x)) + 1e-3
+    assert (
+        np.max(np.abs(both.predict(x))) <= np.max(np.abs(only_linf.predict(x))) + 1e-3
+    )
+
+
+def test_group_lasso_inf_save_load_round_trip(tmp_path: Path) -> None:
+    rng = np.random.default_rng(0)
+    x = rng.uniform(0.0, 1.0, size=50)
+    feat = _SplineFeature(
+        name="x", rel_dof=4.0, regularization={"group_lasso_inf": {"coef": 0.7}}
+    )
+    feat.initialize(
+        x,
+        smoothing=2.0,
+        save_flag=True,
+        save_prefix=str(tmp_path / "model"),
+    )
+    feat._theta = np.linspace(0.0, 1.0, len(feat._theta))
+    feat._save()
+
+    restored = _SplineFeature(load_from_file=feat._filename)
+    assert restored._has_group_lasso_inf
+    assert restored._coef_group_lasso_inf == pytest.approx(0.7)
+    assert restored._lambda_group_lasso_inf == pytest.approx(1.4)
+    np.testing.assert_allclose(restored._theta, feat._theta)
+
+
+def test_group_lasso_inf_within_gam_drops_noise_feature() -> None:
+    rng = np.random.default_rng(2)
+    n = 400
+    signal = rng.uniform(0.0, 1.0, size=n)
+    noise = rng.uniform(0.0, 1.0, size=n)
+    y = np.sin(2 * np.pi * signal) + 0.1 * rng.normal(size=n)
+    y = y - y.mean()
+    X = pd.DataFrame({"signal": signal, "noise": noise})
+
+    mdl = GAM(family="normal")
+    mdl.add_feature(
+        name="signal",
+        type="spline",
+        rel_dof=6.0,
+        regularization={"group_lasso_inf": {"coef": 0.3}},
+    )
+    mdl.add_feature(
+        name="noise",
+        type="spline",
+        rel_dof=6.0,
+        regularization={"group_lasso_inf": {"coef": 0.3}},
+    )
+    mdl.fit(X, y, max_its=40)
+
+    signal_feat = mdl._features["signal"]
+    noise_feat = mdl._features["noise"]
+    signal_pred = signal_feat.predict(signal)
+    noise_pred = noise_feat.predict(noise)
+    signal_norm = float(np.linalg.norm(signal_pred))
+    noise_norm = float(np.linalg.norm(noise_pred))
+    assert signal_norm > 1.0
+    assert noise_norm < 0.2 * signal_norm


### PR DESCRIPTION
Adds regularization={"group_lasso_inf": {"coef": lambda}} as a
companion to the existing L2 group lasso on linear, categorical,
and spline features. Convex by construction, with a different
shrinkage geometry from the L2 variant: coefficient clipping rather
than uniform contraction.

- Linear: penalty reduces to a 1-D soft-threshold with threshold
  lambda_inf * max|x - mean(x)| / rho; stacks additively with the
  existing l1 and L2 group lasso thresholds.
- Categorical: cvxpy norm_inf term on A q, masked to categories
  with observations.
- Spline: cvxpy norm_inf term on N theta; routes through the cvxpy
  path whenever either group-lasso variant is active.

Save/load round-trip updated; older pickles default to disabled.
Tests cover the closed-form linear case, the geometric distinction
on categoricals, additive combination with L2, and end-to-end
"drops the noise feature" within full GAM fits.