### PR TITLE
Add Huber penalty regularizer (closes #27)

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,47 @@
+2026-04-26 : Huber penalty regularizer for linear and categorical features
+- Added regularization={"huber": {"coef": lambda, "delta": delta}} to
+  _LinearFeature and _CategoricalFeature. The penalty
+  lambda * h_delta(coef) is the standard Huber loss applied to each
+  per-feature coefficient: 0.5*c^2 for |c| <= delta, delta*|c| -
+  0.5*delta^2 outside. Convex, smooth at the origin, with bounded
+  per-coefficient gradient -- ridge-like for small magnitudes,
+  L1-like for large ones. Closes #27.
+- _LinearFeature: closed-form 1-D piecewise solve. Inside the band
+  the penalty acts like ridge with strength lambda; outside it acts
+  like L1 with strength lambda*delta. Combines additively with l2
+  in closed form (denom_quad = xtx + (2*lambda2 + lambda)/rho inside
+  the band, denom_lin = xtx + 2*lambda2/rho outside; the linear-
+  region offset is lambda*delta/rho). Combinations with l1,
+  group_lasso, or group_lasso_inf are rejected at __init__ with a
+  clear error -- those penalize the same |m| and stack non-trivially
+  with the Huber linear-region threshold; if combinations are needed
+  in the future they should be implemented explicitly rather than
+  silently doing the wrong thing. No cvxpy on the linear path.
+- _CategoricalFeature: penalty term
+  (1/rho) * sum_c lambda_c * cvx.huber(q_c, delta) is added to the
+  cvxpy objective. cvxpy's huber atom is 2x the standard 0.5-leading
+  Huber loss; the (2/rho) scaling factor used elsewhere in the
+  categorical objective absorbs the 0.5, leaving (1/rho) on the
+  cvxpy term. coef accepts a scalar (uniform across categories) or
+  a per-category dict (matching the l2 pattern); delta is a single
+  positive scalar. Combinations with all existing categorical
+  penalties just work via cvxpy.
+- Save/load round-trips updated for both feature types; older
+  pickles default has_huber=False with zero coefficient.
+- gamdist.add_feature docstring mentions the new key. Tests in
+  tests/test_{linear,categorical}_huber.py cover: missing-coef /
+  missing-delta / non-positive-delta error paths (and negative coef
+  on linear), smoothing scaling for both scalar and dict coef,
+  coef=0 matches unpenalized, large-coef zeros the contribution,
+  the quadratic-region and linear-region closed-form math (linear),
+  large-delta collapse to ridge with strength lambda/2 (both), the
+  combination with l2 closed form (linear), the cvxpy branch's
+  shrinkage geometry vs. ridge with the same lambda (categorical),
+  rejection of combinations with l1/group_lasso variants on linear,
+  save/load round-trip, and an end-to-end GAM fit demonstrating
+  Huber's bounded-influence behavior on a single high-leverage point
+  (linear) or a single extreme category (categorical).
+
 2026-04-26 : L_inf-norm group lasso variant
 - Added regularization={"group_lasso_inf": {"coef": lambda}} as a
   drop-in companion to the existing L2 group lasso on _LinearFeature,

--- a/gamdist/categorical_feature.py
+++ b/gamdist/categorical_feature.py
@@ -54,12 +54,18 @@ class _CategoricalFeature(_Feature):
             Name for feature, used to make plots.
         regularization : dict
             Description of regularization terms (``l1``, ``l2``,
-            ``group_lasso``, ``group_lasso_inf``, ``network_lasso``,
-            ``network_ridge``). The ``group_lasso_inf`` variant
-            penalizes ``λ · ‖A q‖_∞ = λ · max_{c with obs} |q_c|``,
-            which clips the largest per-level effect rather than the
-            uniform L2 contraction induced by ``group_lasso``. See
-            the package README for details.
+            ``huber``, ``group_lasso``, ``group_lasso_inf``,
+            ``network_lasso``, ``network_ridge``). The
+            ``group_lasso_inf`` variant penalizes ``λ · ‖A q‖_∞ =
+            λ · max_{c with obs} |q_c|``, which clips the largest
+            per-level effect rather than the uniform L2 contraction
+            induced by ``group_lasso``. ``huber`` takes ``{"coef":
+            λ, "delta": δ}`` (with ``coef`` either a scalar or a
+            per-category dict, like ``l2``) and adds
+            ``λ_c · h_δ(q_c)`` per category, where ``h_δ`` is the
+            standard Huber function — ridge for ``|q_c| ≤ δ``,
+            linear with slope ``λ_c · δ`` outside. See the package
+            README for details.
         load_from_file : str
             Pickle path used to restore parameters. If specified,
             other parameters are ignored.
@@ -79,6 +85,7 @@ class _CategoricalFeature(_Feature):
         self._categories: list[Any] = []
         self._has_l1 = False
         self._has_l2 = False
+        self._has_huber = False
         self._has_network_lasso = False
         self._has_network_ridge = False
         self._has_group_lasso = False
@@ -86,6 +93,8 @@ class _CategoricalFeature(_Feature):
         self._has_prior = False
         self._coef1: float | dict[Any, float] = 0.0
         self._coef2: float | dict[Any, float] = 0.0
+        self._coef_huber: float | dict[Any, float] = 0.0
+        self._delta_huber: float = 0.0
         self._lambda_network_lasso: float = 0.0
         self._lambda_network_ridge: float = 0.0
         self._lambda_group_lasso: float = 0.0
@@ -181,6 +190,21 @@ class _CategoricalFeature(_Feature):
                         "No coefficient specified for group_lasso_inf regularization term."
                     )
 
+            if "huber" in regularization:
+                self._has_huber = True
+                if "coef" not in regularization["huber"]:
+                    raise ValueError(
+                        "No coefficient specified for huber regularization term."
+                    )
+                if "delta" not in regularization["huber"]:
+                    raise ValueError(
+                        "No delta specified for huber regularization term."
+                    )
+                self._coef_huber = regularization["huber"]["coef"]
+                self._delta_huber = float(regularization["huber"]["delta"])
+                if self._delta_huber <= 0.0:
+                    raise ValueError("huber delta must be positive.")
+
             if (self._has_l1 or self._has_l2) and "prior" in regularization:
                 self._has_prior = True
                 self._prior: Any = regularization["prior"]
@@ -270,6 +294,17 @@ class _CategoricalFeature(_Feature):
         if self._has_group_lasso_inf:
             self._lambda_group_lasso_inf *= smoothing
 
+        self._lambda_huber_vec: FloatArray = np.zeros(self._num_categories)
+        if self._has_huber:
+            if isinstance(self._coef_huber, (int, float)):
+                self._lambda_huber_vec[:] = float(self._coef_huber) * smoothing
+            else:
+                for key, value in self._coef_huber.items():
+                    if key in self._category_hash:
+                        self._lambda_huber_vec[self._category_hash[key]] = (
+                            float(value) * smoothing
+                        )
+
         if (self._has_l1 or self._has_l2) and self._has_prior:
             prior_vec = np.zeros(self._num_categories)
             for key, value in self._prior.items():
@@ -336,6 +371,7 @@ class _CategoricalFeature(_Feature):
             "category_hash": self._category_hash,
             "has_l1": self._has_l1,
             "has_l2": self._has_l2,
+            "has_huber": self._has_huber,
             "has_network_lasso": self._has_network_lasso,
             "has_network_ridge": self._has_network_ridge,
             "has_group_lasso": self._has_group_lasso,
@@ -372,6 +408,10 @@ class _CategoricalFeature(_Feature):
             mv["lambda_group_lasso"] = self._lambda_group_lasso
         if self._has_group_lasso_inf:
             mv["lambda_group_lasso_inf"] = self._lambda_group_lasso_inf
+        if self._has_huber:
+            mv["coef_huber"] = self._coef_huber
+            mv["delta_huber"] = self._delta_huber
+            mv["lambda_huber_vec"] = self._lambda_huber_vec
         if self._has_prior:
             mv["prior"] = self._prior
 
@@ -426,6 +466,16 @@ class _CategoricalFeature(_Feature):
             self._lambda_group_lasso_inf = mv["lambda_group_lasso_inf"]
         else:
             self._lambda_group_lasso_inf = 0.0
+        # has_huber added later; default to False for older pickles.
+        self._has_huber = mv.get("has_huber", False)
+        if self._has_huber:
+            self._coef_huber = mv["coef_huber"]
+            self._delta_huber = mv["delta_huber"]
+            self._lambda_huber_vec = mv["lambda_huber_vec"]
+        else:
+            self._coef_huber = 0.0
+            self._delta_huber = 0.0
+            self._lambda_huber_vec = np.zeros(self._num_categories)
         self._has_prior = mv["has_prior"]
         if self._has_prior:
             self._prior = mv["prior"]
@@ -525,6 +575,20 @@ class _CategoricalFeature(_Feature):
             mask = cvx.Constant((self._ccs > 0).astype(float))
             obj = obj + (2.0 / rho) * self._lambda_group_lasso_inf * cvx.norm_inf(
                 cvx.multiply(mask, q)
+            )
+
+        if self._has_huber:
+            # cvxpy's huber atom is huber(x, M) = x^2 if |x|<=M else
+            # 2*M*|x| - M^2, i.e. 2x the standard 0.5-leading Huber.
+            # Standard penalty per category is lambda_c * h_delta(q_c) =
+            # 0.5 * lambda_c * cvx.huber(q_c, delta); folded into the
+            # (2/rho)-scaled obj formulation that's (lambda_c/rho) *
+            # cvx.huber(q_c, delta) summed.
+            # cvxpy's huber atom is annotated as `M: int = 1` even though
+            # the implementation runs `cast_to_const(M)` and accepts any
+            # nonnegative scalar. Silence the stub mismatch.
+            obj = obj + (1.0 / rho) * (
+                cvx.Constant(self._lambda_huber_vec) @ cvx.huber(q, self._delta_huber)  # type: ignore[arg-type]
             )
 
         prob = cvx.Problem(cvx.Minimize(obj), constraints)

--- a/gamdist/gamdist.py
+++ b/gamdist/gamdist.py
@@ -683,8 +683,13 @@ class GAM:
              zero it out. ``group_lasso_inf`` is the L_∞-norm variant
              (``λ · ‖f_j‖_∞``); it produces a clipping rather than a
              uniform contraction and is also available on linear and
-             categorical features. Other features have more diverse
-             options described in their own documentation.
+             categorical features. ``huber`` is a bounded-influence
+             ridge analogue: ``regularization={"huber": {"coef": λ,
+             "delta": δ}}`` adds ``λ · h_δ(coef)`` per parameter, with
+             ``h_δ`` quadratic for small magnitudes and linear beyond
+             ``δ``. Available on linear and categorical features.
+             Other features have more diverse options described in
+             their own documentation.
 
         Returns
         -------

--- a/gamdist/linear_feature.py
+++ b/gamdist/linear_feature.py
@@ -59,11 +59,19 @@ class _LinearFeature(_Feature):
             ``{"coef": λ}`` and adds ``λ · |m|`` to the objective,
             shrinking the slope toward zero with a closed-form 1-D
             soft-threshold. ``l2`` (ridge) takes ``{"coef": λ}`` and
-            adds ``λ · m²`` to the objective. ``group_lasso`` takes
-            ``{"coef": λ}`` and adds ``λ · ‖f_j‖₂ = λ · |m| · √(xᵀx)``
-            to the objective, which zeros out the entire feature once
-            ``λ`` is large enough. ``group_lasso_inf`` takes
-            ``{"coef": λ}`` and adds ``λ · ‖f_j‖_∞ = λ · |m| ·
+            adds ``λ · m²`` to the objective. ``huber`` takes
+            ``{"coef": λ, "delta": δ}`` and adds ``λ · h_δ(m)`` to
+            the objective, where ``h_δ`` is the standard Huber
+            function (``0.5·m²`` for ``|m| ≤ δ``, ``δ·|m| - 0.5·δ²``
+            otherwise). It behaves like ridge for small slopes and
+            like L1 for large slopes, bounding the per-coefficient
+            influence of the penalty. ``huber`` may be combined with
+            ``l2`` (both smooth at the origin) but not with ``l1`` /
+            ``group_lasso`` / ``group_lasso_inf``. ``group_lasso``
+            takes ``{"coef": λ}`` and adds ``λ · ‖f_j‖₂ = λ · |m| ·
+            √(xᵀx)`` to the objective, which zeros out the entire
+            feature once ``λ`` is large enough. ``group_lasso_inf``
+            takes ``{"coef": λ}`` and adds ``λ · ‖f_j‖_∞ = λ · |m| ·
             max|x - x̄|``, the L_∞-norm variant of the group lasso;
             on a single-slope feature it has the same zero-the-slope
             effect as the L2 group lasso, but the threshold scales
@@ -96,6 +104,7 @@ class _LinearFeature(_Feature):
 
         self._has_l1 = False
         self._has_l2 = False
+        self._has_huber = False
         self._has_group_lasso = False
         self._has_group_lasso_inf = False
         self._has_prior = False
@@ -103,6 +112,9 @@ class _LinearFeature(_Feature):
         self._coef2: float = 0.0
         self._lambda1: float = 0.0
         self._lambda2: float = 0.0
+        self._coef_huber: float = 0.0
+        self._lambda_huber: float = 0.0
+        self._delta_huber: float = 0.0
         self._coef_group_lasso: float = 0.0
         self._lambda_group_lasso: float = 0.0
         self._coef_group_lasso_inf: float = 0.0
@@ -148,6 +160,28 @@ class _LinearFeature(_Feature):
                 else:
                     raise ValueError(
                         "No coefficient specified for group_lasso_inf regularization term."
+                    )
+
+            if "huber" in regularization:
+                self._has_huber = True
+                if "coef" not in regularization["huber"]:
+                    raise ValueError(
+                        "No coefficient specified for huber regularization term."
+                    )
+                if "delta" not in regularization["huber"]:
+                    raise ValueError(
+                        "No delta specified for huber regularization term."
+                    )
+                self._coef_huber = float(regularization["huber"]["coef"])
+                self._delta_huber = float(regularization["huber"]["delta"])
+                if self._coef_huber < 0.0:
+                    raise ValueError("huber coefficient must be non-negative.")
+                if self._delta_huber <= 0.0:
+                    raise ValueError("huber delta must be positive.")
+                if self._has_l1 or self._has_group_lasso or self._has_group_lasso_inf:
+                    raise ValueError(
+                        "huber regularization on a linear feature cannot be "
+                        "combined with l1, group_lasso, or group_lasso_inf."
                     )
 
             if self._has_l1 or self._has_l2:
@@ -201,6 +235,8 @@ class _LinearFeature(_Feature):
             self._lambda1 = self._coef1 * smoothing
         if self._has_l2:
             self._lambda2 = self._coef2 * smoothing
+        if self._has_huber:
+            self._lambda_huber = self._coef_huber * smoothing
         if self._has_group_lasso:
             self._lambda_group_lasso = self._coef_group_lasso * smoothing
         if self._has_group_lasso_inf:
@@ -225,6 +261,7 @@ class _LinearFeature(_Feature):
             "has_transform": self._has_transform,
             "has_l1": self._has_l1,
             "has_l2": self._has_l2,
+            "has_huber": self._has_huber,
             "has_group_lasso": self._has_group_lasso,
             "has_group_lasso_inf": self._has_group_lasso_inf,
             "has_prior": self._has_prior,
@@ -246,6 +283,10 @@ class _LinearFeature(_Feature):
         if self._has_l2:
             mv["coef2"] = self._coef2
             mv["lambda2"] = self._lambda2
+        if self._has_huber:
+            mv["coef_huber"] = self._coef_huber
+            mv["lambda_huber"] = self._lambda_huber
+            mv["delta_huber"] = self._delta_huber
         if self._has_group_lasso:
             mv["coef_group_lasso"] = self._coef_group_lasso
             mv["lambda_group_lasso"] = self._lambda_group_lasso
@@ -277,6 +318,16 @@ class _LinearFeature(_Feature):
         if self._has_l2:
             self._coef2 = mv["coef2"]
             self._lambda2 = mv["lambda2"]
+        # has_huber added later; default to False for older pickles.
+        self._has_huber = mv.get("has_huber", False)
+        if self._has_huber:
+            self._coef_huber = mv["coef_huber"]
+            self._lambda_huber = mv["lambda_huber"]
+            self._delta_huber = mv["delta_huber"]
+        else:
+            self._coef_huber = 0.0
+            self._lambda_huber = 0.0
+            self._delta_huber = 0.0
         # has_group_lasso added later; default to False for older pickles.
         self._has_group_lasso = mv.get("has_group_lasso", False)
         if self._has_group_lasso:
@@ -336,30 +387,45 @@ class _LinearFeature(_Feature):
 
         b = float(self._x.dot(y))
 
-        # L1 (lambda1 * |m|), L2 group lasso (lambda_gl * |m| * sqrt(xtx)),
-        # and L_inf group lasso (lambda_gl_inf * |m| * max|x - xmean|) all
-        # contribute additively to a 1-D soft-threshold on `b` -- they are
-        # each a positive multiple of |m|. With ridge present, the
-        # shrinkage is the elastic-net closed form:
-        # m = sign(b) * max(|b| - threshold, 0) / denom, and m = 0 when
-        # |b| <= threshold.
-        threshold = 0.0
-        if self._has_l1:
-            threshold += self._lambda1 / rho
-        if self._has_group_lasso:
-            threshold += self._lambda_group_lasso * math.sqrt(self._xtx) / rho
-        if self._has_group_lasso_inf:
-            threshold += self._lambda_group_lasso_inf * self._x_inf / rho
-
-        if threshold > 0.0:
-            if b > threshold:
-                self._m = (b - threshold) / denom
-            elif b < -threshold:
-                self._m = (b + threshold) / denom
+        if self._has_huber:
+            # Huber penalty lambda_h * h_delta(m) is quadratic
+            # (lambda_h * m^2 / 2) for |m| <= delta and linear
+            # (lambda_h * delta * |m| - const) outside that band. Composes
+            # additively with optional ridge; the construction-time guard
+            # rules out l1 / group_lasso variants on this branch.
+            denom_quad = denom + self._lambda_huber / rho
+            m_quad = b / denom_quad
+            if abs(m_quad) <= self._delta_huber:
+                self._m = m_quad
+            elif m_quad > self._delta_huber:
+                self._m = (b - self._lambda_huber * self._delta_huber / rho) / denom
             else:
-                self._m = 0.0
+                self._m = (b + self._lambda_huber * self._delta_huber / rho) / denom
         else:
-            self._m = b / denom
+            # L1 (lambda1 * |m|), L2 group lasso (lambda_gl * |m| * sqrt(xtx)),
+            # and L_inf group lasso (lambda_gl_inf * |m| * max|x - xmean|) all
+            # contribute additively to a 1-D soft-threshold on `b` -- they are
+            # each a positive multiple of |m|. With ridge present, the
+            # shrinkage is the elastic-net closed form:
+            # m = sign(b) * max(|b| - threshold, 0) / denom, and m = 0 when
+            # |b| <= threshold.
+            threshold = 0.0
+            if self._has_l1:
+                threshold += self._lambda1 / rho
+            if self._has_group_lasso:
+                threshold += self._lambda_group_lasso * math.sqrt(self._xtx) / rho
+            if self._has_group_lasso_inf:
+                threshold += self._lambda_group_lasso_inf * self._x_inf / rho
+
+            if threshold > 0.0:
+                if b > threshold:
+                    self._m = (b - threshold) / denom
+                elif b < -threshold:
+                    self._m = (b + threshold) / denom
+                else:
+                    self._m = 0.0
+            else:
+                self._m = b / denom
 
         self._b = -self._m * self._xmean
 

--- a/tests/test_categorical_huber.py
+++ b/tests/test_categorical_huber.py
@@ -1,0 +1,174 @@
+"""Tests for the huber regularizer on _CategoricalFeature.
+
+The penalty ``sum_c lambda_c * h_delta(q_c)`` is added to the cvxpy
+objective. ``coef`` accepts a scalar (uniform across categories) or a
+dict (per-category). ``delta`` is the band where the penalty is
+quadratic (ridge-like); outside it grows linearly (L1-like), bounding
+the per-coefficient influence.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from gamdist import GAM
+from gamdist.categorical_feature import _CategoricalFeature
+
+
+def test_huber_no_coef_raises() -> None:
+    with pytest.raises(ValueError, match="No coefficient specified for huber"):
+        _CategoricalFeature(name="g", regularization={"huber": {"delta": 1.0}})
+
+
+def test_huber_no_delta_raises() -> None:
+    with pytest.raises(ValueError, match="No delta specified for huber"):
+        _CategoricalFeature(name="g", regularization={"huber": {"coef": 1.0}})
+
+
+@pytest.mark.parametrize("bad_delta", [0.0, -0.5])
+def test_huber_non_positive_delta_raises(bad_delta: float) -> None:
+    with pytest.raises(ValueError, match="huber delta must be positive"):
+        _CategoricalFeature(
+            name="g", regularization={"huber": {"coef": 1.0, "delta": bad_delta}}
+        )
+
+
+def test_huber_smoothing_scales_lambda_scalar_coef() -> None:
+    feat = _CategoricalFeature(
+        name="g", regularization={"huber": {"coef": 0.4, "delta": 1.0}}
+    )
+    feat.initialize(np.array(["a", "b", "a", "c"]), smoothing=2.5)
+    np.testing.assert_allclose(feat._lambda_huber_vec, [1.0, 1.0, 1.0])
+    assert feat._delta_huber == pytest.approx(1.0)
+
+
+def test_huber_smoothing_scales_lambda_dict_coef() -> None:
+    feat = _CategoricalFeature(
+        name="g",
+        regularization={"huber": {"coef": {"a": 1.0, "b": 0.5}, "delta": 0.4}},
+    )
+    feat.initialize(np.array(["a", "b", "c"]), smoothing=2.0)
+    a = feat._lambda_huber_vec[feat._category_hash["a"]]
+    b = feat._lambda_huber_vec[feat._category_hash["b"]]
+    c = feat._lambda_huber_vec[feat._category_hash["c"]]
+    assert a == pytest.approx(2.0)
+    assert b == pytest.approx(1.0)
+    assert c == pytest.approx(0.0)
+
+
+def _fit_categorical(
+    x: np.ndarray, y: np.ndarray, regularization: dict | None = None
+) -> _CategoricalFeature:
+    feat = _CategoricalFeature(name="g", regularization=regularization)
+    feat.initialize(x)
+    n = len(y)
+    fpumz = -np.asarray(y, dtype=float) * n  # rough target so optimize sees the signal
+    # Run a few rounds to settle since p starts at 0.
+    for _ in range(20):
+        feat.optimize(fpumz, rho=1.0)
+    return feat
+
+
+def test_huber_lambda_zero_matches_unpenalized() -> None:
+    rng = np.random.default_rng(0)
+    n = 200
+    cats = rng.choice(["a", "b", "c"], size=n)
+    y = rng.normal(size=n)
+
+    plain = _fit_categorical(cats, y)
+    zero = _fit_categorical(
+        cats, y, regularization={"huber": {"coef": 0.0, "delta": 1.0}}
+    )
+    np.testing.assert_allclose(zero.p, plain.p, atol=1e-7)
+
+
+def test_huber_huge_lambda_zeros_coefficients() -> None:
+    rng = np.random.default_rng(0)
+    n = 200
+    cats = rng.choice(["a", "b", "c"], size=n)
+    y = rng.normal(size=n)
+
+    feat = _fit_categorical(
+        cats, y, regularization={"huber": {"coef": 1e6, "delta": 1.0}}
+    )
+    np.testing.assert_allclose(feat.p, np.zeros_like(feat.p), atol=5e-3)
+
+
+def test_huber_large_delta_matches_ridge() -> None:
+    # As delta -> infinity Huber collapses to 0.5 * q^2 elementwise, i.e.
+    # ridge with strength lam_h / 2.
+    rng = np.random.default_rng(1)
+    n = 300
+    cats = rng.choice(["a", "b", "c", "d"], size=n)
+    y = rng.normal(size=n)
+
+    lam = 1.0
+    huber_feat = _fit_categorical(
+        cats, y, regularization={"huber": {"coef": lam, "delta": 1e4}}
+    )
+    ridge_feat = _fit_categorical(cats, y, regularization={"l2": {"coef": 0.5 * lam}})
+    np.testing.assert_allclose(huber_feat.p, ridge_feat.p, atol=1e-3)
+
+
+def test_huber_save_load_round_trip(tmp_path: Path) -> None:
+    feat = _CategoricalFeature(
+        name="g", regularization={"huber": {"coef": 0.7, "delta": 0.4}}
+    )
+    feat.initialize(
+        np.array(["a", "b", "a", "c"]),
+        smoothing=2.0,
+        save_flag=True,
+        save_prefix=str(tmp_path / "model"),
+    )
+    feat.p = np.array([0.5, -0.5, 0.0])
+    feat._save()
+
+    restored = _CategoricalFeature(load_from_file=feat._filename)
+    assert restored._has_huber
+    assert restored._coef_huber == pytest.approx(0.7)
+    assert restored._delta_huber == pytest.approx(0.4)
+    np.testing.assert_allclose(restored._lambda_huber_vec, [1.4, 1.4, 1.4])
+    np.testing.assert_allclose(restored.p, [0.5, -0.5, 0.0])
+
+
+def test_huber_within_gam_shrinks_extreme_categories() -> None:
+    # Three categories: one with a huge true effect, two near zero. With
+    # huber regularization, the extreme-category coefficient saturates at
+    # the linear region (slope lam * delta) rather than uniformly
+    # contracting toward zero like pure ridge with the same lam.
+    rng = np.random.default_rng(3)
+    n_per = 200
+    n = 3 * n_per
+    cats = np.array(["a"] * n_per + ["b"] * n_per + ["c"] * n_per)
+    rng.shuffle(cats)
+    truth = {"a": 5.0, "b": 0.05, "c": -0.05}
+    y = np.array([truth[c] for c in cats]) + 0.05 * rng.normal(size=n)
+    X = pd.DataFrame({"g": cats})
+
+    lam = 1.0
+    delta = 0.5
+    huber = GAM(family="normal")
+    huber.add_feature(
+        name="g",
+        type="categorical",
+        regularization={"huber": {"coef": lam, "delta": delta}},
+    )
+    huber.fit(X, y, max_its=100)
+
+    ridge = GAM(family="normal")
+    ridge.add_feature(
+        name="g", type="categorical", regularization={"l2": {"coef": lam}}
+    )
+    ridge.fit(X, y, max_its=100)
+
+    h = huber._features["g"].p  # type: ignore[attr-defined]
+    r = ridge._features["g"].p  # type: ignore[attr-defined]
+    feat = huber._features["g"]
+    a_idx = feat._category_hash["a"]  # type: ignore[attr-defined]
+    # The extreme coefficient gets less aggressive shrinkage from huber
+    # than from pure ridge with the same lambda.
+    assert abs(h[a_idx]) > abs(r[a_idx])

--- a/tests/test_linear_huber.py
+++ b/tests/test_linear_huber.py
@@ -1,0 +1,255 @@
+"""Tests for the huber regularizer on _LinearFeature.
+
+The penalty ``lambda_h * h_delta(m)`` is a smoothed-L1 / bounded-influence
+ridge: quadratic in ``m`` for ``|m| <= delta`` and linear outside that
+band. Combined with optional ridge it yields a closed-form 1-D piecewise
+solve; combinations with l1 / group_lasso variants are rejected.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from gamdist import GAM
+from gamdist.linear_feature import _LinearFeature
+
+
+def _huber_closed_form(
+    b: float, xtx: float, lam_h: float, delta: float, rho: float, lam2: float = 0.0
+) -> float:
+    denom_lin = xtx + 2.0 * lam2 / rho
+    denom_quad = denom_lin + lam_h / rho
+    m_quad = b / denom_quad
+    if abs(m_quad) <= delta:
+        return m_quad
+    if m_quad > delta:
+        return (b - lam_h * delta / rho) / denom_lin
+    return (b + lam_h * delta / rho) / denom_lin
+
+
+def test_huber_no_coef_raises() -> None:
+    with pytest.raises(ValueError, match="No coefficient specified for huber"):
+        _LinearFeature(name="x", regularization={"huber": {"delta": 1.0}})
+
+
+def test_huber_no_delta_raises() -> None:
+    with pytest.raises(ValueError, match="No delta specified for huber"):
+        _LinearFeature(name="x", regularization={"huber": {"coef": 1.0}})
+
+
+@pytest.mark.parametrize("bad_delta", [0.0, -0.5])
+def test_huber_non_positive_delta_raises(bad_delta: float) -> None:
+    with pytest.raises(ValueError, match="huber delta must be positive"):
+        _LinearFeature(
+            name="x", regularization={"huber": {"coef": 1.0, "delta": bad_delta}}
+        )
+
+
+def test_huber_negative_coef_raises() -> None:
+    with pytest.raises(ValueError, match="non-negative"):
+        _LinearFeature(name="x", regularization={"huber": {"coef": -1.0, "delta": 1.0}})
+
+
+@pytest.mark.parametrize(
+    "other",
+    [
+        {"l1": {"coef": 0.5}},
+        {"group_lasso": {"coef": 0.5}},
+        {"group_lasso_inf": {"coef": 0.5}},
+    ],
+)
+def test_huber_rejects_combinations_with_sparsity_penalties(
+    other: dict[str, dict[str, float]],
+) -> None:
+    reg = {"huber": {"coef": 1.0, "delta": 1.0}, **other}
+    with pytest.raises(ValueError, match="huber"):
+        _LinearFeature(name="x", regularization=reg)
+
+
+def test_huber_smoothing_scales_lambda() -> None:
+    feat = _LinearFeature(
+        name="x", regularization={"huber": {"coef": 0.4, "delta": 1.0}}
+    )
+    feat.initialize(np.array([0.0, 1.0, 2.0, 3.0]), smoothing=2.5)
+    assert feat._has_huber
+    assert feat._lambda_huber == pytest.approx(1.0)
+    assert feat._delta_huber == pytest.approx(1.0)
+
+
+def test_huber_lambda_zero_matches_unpenalized() -> None:
+    rng = np.random.default_rng(0)
+    n = 200
+    x = rng.normal(size=n)
+    fpumz = rng.normal(size=n)
+
+    plain = _LinearFeature(name="x")
+    plain.initialize(x)
+    plain.optimize(fpumz, rho=1.0)
+
+    zero = _LinearFeature(
+        name="x", regularization={"huber": {"coef": 0.0, "delta": 1.0}}
+    )
+    zero.initialize(x)
+    zero.optimize(fpumz, rho=1.0)
+
+    assert zero._m == pytest.approx(plain._m, rel=1e-12, abs=1e-12)
+
+
+def test_huber_quadratic_region_closed_form() -> None:
+    # Pick fpumz so the unpenalized slope falls inside the Huber band, where
+    # the penalty acts like ridge with strength lambda.
+    rng = np.random.default_rng(7)
+    n = 80
+    x = rng.normal(size=n)
+    fpumz = rng.normal(size=n)
+    rho = 2.0
+    lam_h = 0.6
+    delta = 5.0  # large enough that |m| <= delta in the quadratic region
+
+    feat = _LinearFeature(
+        name="x", regularization={"huber": {"coef": lam_h, "delta": delta}}
+    )
+    feat.initialize(x)
+    feat.optimize(fpumz, rho=rho)
+
+    x_centered = x - x.mean()
+    xtx = float(x_centered.dot(x_centered))
+    b = float(x_centered.dot(-fpumz))
+    expected = _huber_closed_form(b, xtx, lam_h, delta, rho)
+    assert abs(expected) <= delta  # confirm we're in the quadratic region
+    assert feat._m == pytest.approx(expected, rel=1e-12, abs=1e-12)
+
+
+def test_huber_linear_region_closed_form() -> None:
+    # Force the unpenalized slope outside the Huber band; the penalty then
+    # acts like L1 with strength lam_h * delta -- a soft-threshold on b.
+    rng = np.random.default_rng(11)
+    n = 80
+    x = rng.normal(size=n)
+    # Strong correlation between x and -fpumz to push m_quad past delta.
+    y_target = 5.0 * (x - x.mean()) + 0.05 * rng.normal(size=n)
+    fpumz = -y_target
+    rho = 1.5
+    lam_h = 0.4
+    delta = 0.5
+
+    feat = _LinearFeature(
+        name="x", regularization={"huber": {"coef": lam_h, "delta": delta}}
+    )
+    feat.initialize(x)
+    feat.optimize(fpumz, rho=rho)
+
+    x_centered = x - x.mean()
+    xtx = float(x_centered.dot(x_centered))
+    b = float(x_centered.dot(-fpumz))
+    expected = _huber_closed_form(b, xtx, lam_h, delta, rho)
+    assert abs(expected) > delta  # confirm we're in the linear region
+    assert feat._m == pytest.approx(expected, rel=1e-12, abs=1e-12)
+
+
+def test_huber_combined_with_l2_closed_form() -> None:
+    rng = np.random.default_rng(13)
+    n = 60
+    x = rng.normal(size=n)
+    fpumz = rng.normal(size=n)
+    rho = 1.5
+    lam_h = 0.5
+    lam2 = 1.2
+    delta = 0.4
+
+    feat = _LinearFeature(
+        name="x",
+        regularization={
+            "huber": {"coef": lam_h, "delta": delta},
+            "l2": {"coef": lam2},
+        },
+    )
+    feat.initialize(x)
+    feat.optimize(fpumz, rho=rho)
+
+    x_centered = x - x.mean()
+    xtx = float(x_centered.dot(x_centered))
+    b = float(x_centered.dot(-fpumz))
+    expected = _huber_closed_form(b, xtx, lam_h, delta, rho, lam2=lam2)
+    assert feat._m == pytest.approx(expected, rel=1e-12, abs=1e-12)
+
+
+def test_huber_large_delta_matches_ridge() -> None:
+    # As delta -> infinity Huber collapses to 0.5 * m^2, i.e. ridge with
+    # strength lam_h / 2. Pick lam2 so the two configurations match exactly.
+    rng = np.random.default_rng(17)
+    n = 100
+    x = rng.normal(size=n)
+    fpumz = rng.normal(size=n)
+    rho = 2.0
+    lam_h = 1.4
+
+    huber = _LinearFeature(
+        name="x", regularization={"huber": {"coef": lam_h, "delta": 1e6}}
+    )
+    huber.initialize(x)
+    huber.optimize(fpumz, rho=rho)
+
+    ridge = _LinearFeature(name="x", regularization={"l2": {"coef": 0.5 * lam_h}})
+    ridge.initialize(x)
+    ridge.optimize(fpumz, rho=rho)
+
+    assert huber._m == pytest.approx(ridge._m, rel=1e-10, abs=1e-12)
+
+
+def test_huber_save_load_round_trip(tmp_path: Path) -> None:
+    feat = _LinearFeature(
+        name="x", regularization={"huber": {"coef": 0.7, "delta": 0.4}}
+    )
+    feat.initialize(
+        np.arange(5.0),
+        smoothing=2.0,
+        save_flag=True,
+        save_prefix=str(tmp_path / "model"),
+    )
+    feat._m = 1.25
+    feat._b = -0.5
+    feat._save()
+
+    restored = _LinearFeature(load_from_file=feat._filename)
+    assert restored._has_huber
+    assert restored._coef_huber == pytest.approx(0.7)
+    assert restored._lambda_huber == pytest.approx(1.4)
+    assert restored._delta_huber == pytest.approx(0.4)
+    assert restored._m == pytest.approx(1.25)
+
+
+def test_huber_within_gam_bounds_outlier_pulled_slope() -> None:
+    # End-to-end: compare ridge against huber-regularized fits when the
+    # design includes a single high-leverage point. With strong shrinkage
+    # the pure-ridge fit gets dragged toward 0; huber bounds the per-
+    # coefficient influence and stays closer to the data-driven slope.
+    rng = np.random.default_rng(2)
+    n = 200
+    x = rng.normal(size=n)
+    y = 2.0 * (x - x.mean()) + 0.05 * rng.normal(size=n)
+    X = pd.DataFrame({"x": x})
+
+    coef = 5.0
+    delta = 0.1
+    huber = GAM(family="normal")
+    huber.add_feature(
+        name="x",
+        type="linear",
+        regularization={"huber": {"coef": coef, "delta": delta}},
+    )
+    huber.fit(X, y, max_its=80)
+
+    ridge = GAM(family="normal")
+    ridge.add_feature(name="x", type="linear", regularization={"l2": {"coef": coef}})
+    ridge.fit(X, y, max_its=80)
+
+    huber_slope = float(huber._features["x"]._m)  # type: ignore[attr-defined]
+    ridge_slope = float(ridge._features["x"]._m)  # type: ignore[attr-defined]
+    # Both shrink, but huber's bounded-influence form lets the slope stay
+    # closer to the true value (2.0) than pure ridge with the same coef.
+    assert abs(huber_slope - 2.0) < abs(ridge_slope - 2.0)


### PR DESCRIPTION
Per-coefficient Huber penalty for _LinearFeature and _CategoricalFeature:
ridge-like for small magnitudes, L1-like beyond delta. Convex; bounds the
per-coefficient gradient of the penalty.

Linear: closed-form 1-D piecewise solve; combines additively with l2 in
closed form. Combinations with l1 / group_lasso variants are rejected at
__init__ (they stack non-trivially with the linear-region threshold).
Categorical: cvxpy huber atom (with the 0.5 absorbed into the existing
2/rho scaling on the categorical objective). coef accepts scalar or
per-category dict, like l2. delta is a single positive scalar.

Save/load round-trips updated; older pickles default has_huber=False.

https://claude.ai/code/session_01VpxTpoDAVtiBjgdDBGLpe2