### PR TITLE
Add convex shape constraints on feature coefficients (closes #30)

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,54 @@
+2026-04-26 : Convex shape constraints on feature coefficients
+- Added a `constraints={...}` keyword to `GAM.add_feature` and to each
+  feature class. Supported keys: `sign` (`"nonnegative"` /
+  `"nonpositive"`), `lower` / `upper` (floats), `monotonic`
+  (`"increasing"` / `"decreasing"`), `convex`, and `concave`. All are
+  linear inequality constraints, so every per-feature subproblem stays
+  convex (CLAUDE.md North Star).
+- _LinearFeature: only sign / lower / upper apply (a single slope has no
+  meaningful monotonicity / curvature). The closed-form 1-D optimum is
+  projected onto `[lower, upper]` -- a no-op when the unconstrained
+  minimum is already feasible. No cvxpy on this path; the new step is a
+  one-line clip after the existing soft-threshold / Huber math.
+- _CategoricalFeature: drops linear-inequality terms into the existing
+  cvxpy program. `lower` / `upper` clip every `q_c`. `monotonic` /
+  `convex` / `concave` require an `order` list of category labels and
+  emit consecutive-difference / second-difference constraints along
+  that order. The implicit zero-sum constraint is preserved, so one-
+  sided sign constraints collapse the entire vector to zero -- they
+  exist for symmetry and for the regulated "no negative effects"
+  interpretation. Categories appearing only in the order list are
+  added to the feature's known category set so the optimize step can
+  reference their indices.
+- _SplineFeature: shape constraints land on the spline evaluated at the
+  knots `xi`. `initialize` now also stores the basis matrix `N_xi` of
+  shape (K, K) so the optimize step can express
+  `f_xi = N_xi @ theta` cheaply. `lower` / `upper` clip the knot
+  values; `monotonic` / `convex` / `concave` use `cvx.diff` to encode
+  consecutive / second differences along the sorted knots. Constraint
+  enforcement at the knots is a near-global proxy for a smooth cubic
+  spline. `optimize()` routes through `_optimize_cvx` whenever
+  constraints (or either group lasso) is active; the closed-form
+  Cholesky path is preserved when none are active. The constrained
+  QP can hit CLARABEL's numerical-tolerance failure on dense knot
+  grids with many active inequality constraints, so `_optimize_cvx`
+  catches `cvx.SolverError` and retries with SCS once before
+  surfacing the failure.
+- Save / load round-trips for all three feature types updated; older
+  pickles default `has_constraints` to False with empty bounds /
+  ordering. `_SplineFeature._load` rebuilds `N_xi` from the persisted
+  knots when loading older pickles that don't store it.
+- gamdist.add_feature gained docstring text describing the new kwarg.
+- Tests in `tests/test_constraints.py` cover: API validation paths
+  (unknown keys, sign / lower-upper exclusivity, sign on linear,
+  monotonic on linear, missing order on categorical, duplicates /
+  too-short order, mutually-exclusive convex / concave, inverted
+  bounds), unconstrained-violates-constraint demonstrations for each
+  constraint type, save/load round-trips for all three feature types,
+  and end-to-end GAM fits (linear sign clipping, categorical
+  monotonic-increasing across three levels, spline monotonic on a
+  triangle-wave dose-response signal).
+
 2026-04-26 : Huber penalty regularizer for linear and categorical features
 - Added regularization={"huber": {"coef": lambda, "delta": delta}} to
   _LinearFeature and _CategoricalFeature. The penalty

--- a/gamdist/categorical_feature.py
+++ b/gamdist/categorical_feature.py
@@ -44,6 +44,7 @@ class _CategoricalFeature(_Feature):
         self,
         name: str | None = None,
         regularization: dict[str, Any] | None = None,
+        constraints: dict[str, Any] | None = None,
         load_from_file: str | None = None,
     ) -> None:
         """Initialize feature model (independent of data).
@@ -66,6 +67,22 @@ class _CategoricalFeature(_Feature):
             standard Huber function — ridge for ``|q_c| ≤ δ``,
             linear with slope ``λ_c · δ`` outside. See the package
             README for details.
+        constraints : dict
+            Optional convex shape constraints on the per-category
+            coefficient vector ``q``. ``lower`` / ``upper`` take floats
+            and bound every ``q_c``. ``sign`` (``"nonnegative"`` or
+            ``"nonpositive"``) is shorthand for one-sided ``lower=0`` /
+            ``upper=0`` and may not combine with ``lower`` / ``upper``.
+            ``monotonic`` (``"increasing"`` or ``"decreasing"``),
+            ``convex``, and ``concave`` impose ordering / second-
+            difference constraints along a user-supplied ``order``
+            (a list of category labels). The category zero-sum
+            constraint is preserved, so ``sign`` constraints will
+            collapse the entire vector to zero -- they exist for the
+            occasional regulated use case where that is the desired
+            "no negative effects" outcome and for symmetry with
+            linear features. All constraints append to the existing
+            cvxpy program in ``optimize``.
         load_from_file : str
             Pickle path used to restore parameters. If specified,
             other parameters are ignored.
@@ -208,6 +225,97 @@ class _CategoricalFeature(_Feature):
             if (self._has_l1 or self._has_l2) and "prior" in regularization:
                 self._has_prior = True
                 self._prior: Any = regularization["prior"]
+
+        self._has_constraints = False
+        self._constraint_lower: float = -np.inf
+        self._constraint_upper: float = np.inf
+        self._constraint_monotonic: str | None = None
+        self._constraint_convex: bool = False
+        self._constraint_concave: bool = False
+        self._constraint_order: list[Any] = []
+        if constraints is not None:
+            self._has_constraints = True
+            allowed = {
+                "sign",
+                "lower",
+                "upper",
+                "monotonic",
+                "convex",
+                "concave",
+                "order",
+            }
+            for key in constraints:
+                if key not in allowed:
+                    raise ValueError(f"unknown constraint key {key!r}.")
+            if "sign" in constraints and (
+                "lower" in constraints or "upper" in constraints
+            ):
+                raise ValueError(
+                    "constraints: 'sign' is shorthand for 'lower' / 'upper' and "
+                    "may not be combined with them."
+                )
+            if "sign" in constraints:
+                sign = constraints["sign"]
+                if sign == "nonnegative":
+                    self._constraint_lower = 0.0
+                elif sign == "nonpositive":
+                    self._constraint_upper = 0.0
+                else:
+                    raise ValueError(
+                        f"constraints['sign']: expected 'nonnegative' or "
+                        f"'nonpositive', got {sign!r}."
+                    )
+            if "lower" in constraints:
+                self._constraint_lower = float(constraints["lower"])
+            if "upper" in constraints:
+                self._constraint_upper = float(constraints["upper"])
+            if self._constraint_lower > self._constraint_upper:
+                raise ValueError(
+                    f"constraints: lower ({self._constraint_lower}) exceeds "
+                    f"upper ({self._constraint_upper})."
+                )
+            if "convex" in constraints and "concave" in constraints:
+                raise ValueError(
+                    "constraints: 'convex' and 'concave' are mutually exclusive."
+                )
+            if "monotonic" in constraints:
+                direction = constraints["monotonic"]
+                if direction not in {"increasing", "decreasing"}:
+                    raise ValueError(
+                        f"constraints['monotonic']: expected 'increasing' or "
+                        f"'decreasing', got {direction!r}."
+                    )
+                self._constraint_monotonic = direction
+            if constraints.get("convex"):
+                self._constraint_convex = True
+            if constraints.get("concave"):
+                self._constraint_concave = True
+            needs_order = (
+                self._constraint_monotonic is not None
+                or self._constraint_convex
+                or self._constraint_concave
+            )
+            if needs_order:
+                if "order" not in constraints:
+                    raise ValueError(
+                        "constraints: 'monotonic' / 'convex' / 'concave' on a "
+                        "categorical feature require an 'order' list of category "
+                        "labels defining the sequence."
+                    )
+                order = list(constraints["order"])
+                if len(order) < 2:
+                    raise ValueError(
+                        "constraints['order']: need at least two categories."
+                    )
+                if len(set(order)) != len(order):
+                    raise ValueError("constraints['order']: categories must be unique.")
+                self._constraint_order = order
+                # Categories listed in `order` are added to the feature's known
+                # category set so the optimize step can reference their indices
+                # even if the training data never observes them.
+                for cat in order:
+                    if cat not in self._categories:
+                        self._categories.append(cat)
 
     def initialize(
         self,
@@ -414,6 +522,14 @@ class _CategoricalFeature(_Feature):
             mv["lambda_huber_vec"] = self._lambda_huber_vec
         if self._has_prior:
             mv["prior"] = self._prior
+        if self._has_constraints:
+            mv["has_constraints"] = True
+            mv["constraint_lower"] = self._constraint_lower
+            mv["constraint_upper"] = self._constraint_upper
+            mv["constraint_monotonic"] = self._constraint_monotonic
+            mv["constraint_convex"] = self._constraint_convex
+            mv["constraint_concave"] = self._constraint_concave
+            mv["constraint_order"] = self._constraint_order
 
         with open(self._filename, "wb") as f:
             pickle.dump(mv, f)
@@ -479,6 +595,22 @@ class _CategoricalFeature(_Feature):
         self._has_prior = mv["has_prior"]
         if self._has_prior:
             self._prior = mv["prior"]
+        # has_constraints added later; default to False for older pickles.
+        self._has_constraints = mv.get("has_constraints", False)
+        if self._has_constraints:
+            self._constraint_lower = mv["constraint_lower"]
+            self._constraint_upper = mv["constraint_upper"]
+            self._constraint_monotonic = mv["constraint_monotonic"]
+            self._constraint_convex = mv["constraint_convex"]
+            self._constraint_concave = mv["constraint_concave"]
+            self._constraint_order = mv["constraint_order"]
+        else:
+            self._constraint_lower = -np.inf
+            self._constraint_upper = np.inf
+            self._constraint_monotonic = None
+            self._constraint_convex = False
+            self._constraint_concave = False
+            self._constraint_order = []
         self._na_index = mv["na_index"]
         self.x = mv["x"]
         self.p = mv["p"]
@@ -531,6 +663,30 @@ class _CategoricalFeature(_Feature):
 
         c = cvx.Constant(self._ccs)
         constraints: list[Any] = [c.T @ q == 0]
+
+        if self._has_constraints:
+            if np.isfinite(self._constraint_lower):
+                constraints.append(q >= self._constraint_lower)
+            if np.isfinite(self._constraint_upper):
+                constraints.append(q <= self._constraint_upper)
+            if self._constraint_order:
+                idx = [self._category_hash[cat] for cat in self._constraint_order]
+                if self._constraint_monotonic == "increasing":
+                    for i in range(len(idx) - 1):
+                        constraints.append(q[idx[i + 1]] >= q[idx[i]])
+                elif self._constraint_monotonic == "decreasing":
+                    for i in range(len(idx) - 1):
+                        constraints.append(q[idx[i + 1]] <= q[idx[i]])
+                if self._constraint_convex:
+                    for i in range(1, len(idx) - 1):
+                        constraints.append(
+                            q[idx[i + 1]] - 2.0 * q[idx[i]] + q[idx[i - 1]] >= 0
+                        )
+                if self._constraint_concave:
+                    for i in range(1, len(idx) - 1):
+                        constraints.append(
+                            q[idx[i + 1]] - 2.0 * q[idx[i]] + q[idx[i - 1]] <= 0
+                        )
 
         if self._has_l1:
             q_prior = self._prior if self._has_prior else np.zeros(self._num_categories)

--- a/gamdist/gamdist.py
+++ b/gamdist/gamdist.py
@@ -623,6 +623,7 @@ class GAM:
         transform: Callable[[npt.NDArray[Any]], npt.NDArray[Any]] | None = None,
         rel_dof: float | None = None,
         regularization: dict[str, Any] | None = None,
+        constraints: dict[str, Any] | None = None,
     ) -> None:
         """Add a feature
 
@@ -690,6 +691,18 @@ class GAM:
              ``δ``. Available on linear and categorical features.
              Other features have more diverse options described in
              their own documentation.
+        constraints : dictionary or None
+             Optional convex shape constraints on the feature's
+             coefficients. ``sign`` (``"nonnegative"`` /
+             ``"nonpositive"``), ``lower`` and ``upper`` (floats) bound
+             coefficients. ``monotonic`` (``"increasing"`` /
+             ``"decreasing"``), ``convex`` and ``concave`` impose
+             ordering / second-difference constraints (categorical
+             features additionally require an ``order`` list of
+             category labels; splines order along the knots).
+             Linear features support only ``sign`` / ``lower`` /
+             ``upper``. See each feature class's docstring for
+             details.
 
         Returns
         -------
@@ -698,15 +711,23 @@ class GAM:
         """
         f: _Feature
         if type == "categorical":
-            f = _CategoricalFeature(name, regularization=regularization)
+            f = _CategoricalFeature(
+                name, regularization=regularization, constraints=constraints
+            )
         elif type == "linear":
-            f = _LinearFeature(name, transform, regularization=regularization)
+            f = _LinearFeature(
+                name,
+                transform,
+                regularization=regularization,
+                constraints=constraints,
+            )
         elif type == "spline":
             f = _SplineFeature(
                 name,
                 transform,
                 rel_dof if rel_dof is not None else 4.0,
                 regularization=regularization,
+                constraints=constraints,
             )
         else:
             raise ValueError(f"Features of type {type} not supported.")

--- a/gamdist/linear_feature.py
+++ b/gamdist/linear_feature.py
@@ -44,6 +44,7 @@ class _LinearFeature(_Feature):
         name: str | None = None,
         transform: Transform | None = None,
         regularization: dict[str, Any] | None = None,
+        constraints: dict[str, Any] | None = None,
         load_from_file: str | None = None,
     ) -> None:
         """Initialize feature model (independent of data).
@@ -80,6 +81,19 @@ class _LinearFeature(_Feature):
             additively in the soft-threshold and stack with ``l2``
             (elastic net). The top-level ``prior`` key (if present)
             provides a scalar prior estimate for the slope.
+        constraints : dict
+            Optional convex shape constraints on the slope. ``sign``
+            takes ``"nonnegative"`` (``m ≥ 0``) or ``"nonpositive"``
+            (``m ≤ 0``); ``lower`` and ``upper`` take floats and bound
+            ``m`` from below / above. ``sign`` is shorthand and may
+            not be combined with ``lower`` / ``upper``. The
+            single-slope linear feature does not support ``monotonic``
+            / ``convex`` / ``concave`` (those are well-defined only
+            on multi-coefficient features); passing them raises.
+            Constraints clip the per-feature primal step's
+            unconstrained closed-form solution -- the objective is
+            convex in ``m``, so projection onto ``[lower, upper]`` is
+            the constrained optimum. No cvxpy on this path.
         load_from_file : str
             If provided, restore parameters from this pickle path. All
             other parameters are ignored when loading.
@@ -188,6 +202,47 @@ class _LinearFeature(_Feature):
                 self._has_prior = True
                 self._prior = float(regularization.get("prior", 0.0))
 
+        self._lower: float = -np.inf
+        self._upper: float = np.inf
+        self._has_constraints = False
+        if constraints is not None:
+            self._has_constraints = True
+            for key in constraints:
+                if key not in {"sign", "lower", "upper"}:
+                    if key in {"monotonic", "convex", "concave", "order"}:
+                        raise ValueError(
+                            f"linear feature does not support constraint {key!r}; "
+                            "monotonicity / convexity require a multi-coefficient "
+                            "feature (categorical or spline)."
+                        )
+                    raise ValueError(f"unknown constraint key {key!r}.")
+            if "sign" in constraints and (
+                "lower" in constraints or "upper" in constraints
+            ):
+                raise ValueError(
+                    "constraints: 'sign' is shorthand for 'lower' / 'upper' and may "
+                    "not be combined with them."
+                )
+            if "sign" in constraints:
+                sign = constraints["sign"]
+                if sign == "nonnegative":
+                    self._lower = 0.0
+                elif sign == "nonpositive":
+                    self._upper = 0.0
+                else:
+                    raise ValueError(
+                        f"constraints['sign']: expected 'nonnegative' or "
+                        f"'nonpositive', got {sign!r}."
+                    )
+            if "lower" in constraints:
+                self._lower = float(constraints["lower"])
+            if "upper" in constraints:
+                self._upper = float(constraints["upper"])
+            if self._lower > self._upper:
+                raise ValueError(
+                    f"constraints: lower ({self._lower}) exceeds upper ({self._upper})."
+                )
+
     def initialize(
         self,
         x: npt.NDArray[Any],
@@ -295,6 +350,10 @@ class _LinearFeature(_Feature):
             mv["lambda_group_lasso_inf"] = self._lambda_group_lasso_inf
         if self._has_prior:
             mv["prior"] = self._prior
+        if self._has_constraints:
+            mv["has_constraints"] = True
+            mv["lower"] = self._lower
+            mv["upper"] = self._upper
 
         with open(self._filename, "wb") as f:
             pickle.dump(mv, f)
@@ -347,6 +406,14 @@ class _LinearFeature(_Feature):
         self._has_prior = mv["has_prior"]
         if self._has_prior:
             self._prior = mv["prior"]
+        # has_constraints added later; default to False for older pickles.
+        self._has_constraints = mv.get("has_constraints", False)
+        if self._has_constraints:
+            self._lower = mv["lower"]
+            self._upper = mv["upper"]
+        else:
+            self._lower = -np.inf
+            self._upper = np.inf
 
         self._verbose = mv["verbose"]
         self._name = mv["name"]
@@ -426,6 +493,15 @@ class _LinearFeature(_Feature):
                     self._m = 0.0
             else:
                 self._m = b / denom
+
+        if self._has_constraints:
+            # Objective in m is convex (quadratic + piecewise-linear penalty),
+            # so projecting the unconstrained minimizer onto [lower, upper] is
+            # the constrained optimum.
+            if self._m < self._lower:
+                self._m = self._lower
+            elif self._m > self._upper:
+                self._m = self._upper
 
         self._b = -self._m * self._xmean
 

--- a/gamdist/spline_feature.py
+++ b/gamdist/spline_feature.py
@@ -186,6 +186,7 @@ class _SplineFeature(_Feature):
         transform: Transform | None = None,
         rel_dof: float = 4.0,
         regularization: dict[str, Any] | None = None,
+        constraints: dict[str, Any] | None = None,
         load_from_file: str | None = None,
     ) -> None:
         """Initialize feature model (independent of data).
@@ -207,6 +208,22 @@ class _SplineFeature(_Feature):
             variant clips the largest pointwise contribution rather than
             applying uniform L2 contraction. The two variants combine
             additively when both are specified.
+        constraints : dict
+            Optional convex shape constraints on the fitted spline
+            evaluated at the knots ``xi``. ``lower`` / ``upper`` take
+            floats and bound the spline value. ``sign``
+            (``"nonnegative"`` or ``"nonpositive"``) is shorthand and
+            may not combine with ``lower`` / ``upper``. ``monotonic``
+            (``"increasing"`` or ``"decreasing"``) constrains
+            consecutive knot values; ``convex`` / ``concave`` bound
+            the second differences of the knot values. Knots are
+            sorted, so the constraints are applied along the natural
+            ordering. Constraint enforcement at the knots is a near-
+            global proxy for the smooth cubic spline (sufficient in
+            practice for the intended dose-response / regulated use
+            cases). Constraints append to the cvxpy program in
+            ``optimize`` -- the closed-form Cholesky path is only
+            used when no constraints and no group lasso are active.
         load_from_file : str
             If provided, restore parameters from this pickle path. All
             other parameters are ignored when loading.
@@ -258,6 +275,62 @@ class _SplineFeature(_Feature):
                     "No coefficient specified for group_lasso_inf regularization term."
                 )
 
+        self._has_constraints = False
+        self._constraint_lower: float = -np.inf
+        self._constraint_upper: float = np.inf
+        self._constraint_monotonic: str | None = None
+        self._constraint_convex: bool = False
+        self._constraint_concave: bool = False
+        if constraints is not None:
+            self._has_constraints = True
+            allowed = {"sign", "lower", "upper", "monotonic", "convex", "concave"}
+            for key in constraints:
+                if key not in allowed:
+                    raise ValueError(f"unknown constraint key {key!r}.")
+            if "sign" in constraints and (
+                "lower" in constraints or "upper" in constraints
+            ):
+                raise ValueError(
+                    "constraints: 'sign' is shorthand for 'lower' / 'upper' and "
+                    "may not be combined with them."
+                )
+            if "sign" in constraints:
+                sign = constraints["sign"]
+                if sign == "nonnegative":
+                    self._constraint_lower = 0.0
+                elif sign == "nonpositive":
+                    self._constraint_upper = 0.0
+                else:
+                    raise ValueError(
+                        f"constraints['sign']: expected 'nonnegative' or "
+                        f"'nonpositive', got {sign!r}."
+                    )
+            if "lower" in constraints:
+                self._constraint_lower = float(constraints["lower"])
+            if "upper" in constraints:
+                self._constraint_upper = float(constraints["upper"])
+            if self._constraint_lower > self._constraint_upper:
+                raise ValueError(
+                    f"constraints: lower ({self._constraint_lower}) exceeds "
+                    f"upper ({self._constraint_upper})."
+                )
+            if "convex" in constraints and "concave" in constraints:
+                raise ValueError(
+                    "constraints: 'convex' and 'concave' are mutually exclusive."
+                )
+            if "monotonic" in constraints:
+                direction = constraints["monotonic"]
+                if direction not in {"increasing", "decreasing"}:
+                    raise ValueError(
+                        f"constraints['monotonic']: expected 'increasing' or "
+                        f"'decreasing', got {direction!r}."
+                    )
+                self._constraint_monotonic = direction
+            if constraints.get("convex"):
+                self._constraint_convex = True
+            if constraints.get("concave"):
+                self._constraint_concave = True
+
     def initialize(
         self,
         x: npt.NDArray[Any],
@@ -290,6 +363,13 @@ class _SplineFeature(_Feature):
         self._N = N
         self._NtN = N.transpose().dot(N)
         self._Omega = _omega_curvature(self._xi)
+        # Spline basis evaluated at the knots themselves -- used by shape
+        # constraints to land at the natural cubic-regression-spline anchor
+        # points.
+        N_xi = np.zeros((num_knots, num_knots))
+        for i in range(num_knots):
+            N_xi[i, :] = _evaluate_spline_basis(self._xi[i], self._xi)
+        self._N_xi = N_xi
         self._theta = np.zeros(num_knots)
         self._lmbda = _determine_smoothing(self._NtN, self._Omega, self._rel_dof)
         self._computed_cho_factor = False
@@ -334,6 +414,7 @@ class _SplineFeature(_Feature):
             "verbose": self._verbose,
             "xi": np.asarray(self._xi),
             "N": self._N,
+            "N_xi": self._N_xi,
             "NtN": self._NtN,
             "Omega": self._Omega,
             "theta": self._theta,
@@ -354,6 +435,13 @@ class _SplineFeature(_Feature):
         if self._has_group_lasso_inf:
             mv["coef_group_lasso_inf"] = self._coef_group_lasso_inf
             mv["lambda_group_lasso_inf"] = self._lambda_group_lasso_inf
+        if self._has_constraints:
+            mv["has_constraints"] = True
+            mv["constraint_lower"] = self._constraint_lower
+            mv["constraint_upper"] = self._constraint_upper
+            mv["constraint_monotonic"] = self._constraint_monotonic
+            mv["constraint_convex"] = self._constraint_convex
+            mv["constraint_concave"] = self._constraint_concave
 
         with open(self._filename, "wb") as f:
             pickle.dump(mv, f)
@@ -375,6 +463,17 @@ class _SplineFeature(_Feature):
         self._verbose = mv["verbose"]
         self._xi = mv["xi"]
         self._N = mv["N"]
+        # N_xi added alongside constraints; recover for older pickles by
+        # rebuilding from the persisted knots.
+        if "N_xi" in mv:
+            self._N_xi = mv["N_xi"]
+        else:
+            xi = np.asarray(self._xi)
+            num_knots = len(xi)
+            N_xi = np.zeros((num_knots, num_knots))
+            for i in range(num_knots):
+                N_xi[i, :] = _evaluate_spline_basis(xi[i], xi)
+            self._N_xi = N_xi
         self._NtN = mv["NtN"]
         self._Omega = mv["Omega"]
         self._theta = mv["theta"]
@@ -403,6 +502,20 @@ class _SplineFeature(_Feature):
         else:
             self._coef_group_lasso_inf = 0.0
             self._lambda_group_lasso_inf = 0.0
+        # has_constraints added later; default to False for older pickles.
+        self._has_constraints = mv.get("has_constraints", False)
+        if self._has_constraints:
+            self._constraint_lower = mv["constraint_lower"]
+            self._constraint_upper = mv["constraint_upper"]
+            self._constraint_monotonic = mv["constraint_monotonic"]
+            self._constraint_convex = mv["constraint_convex"]
+            self._constraint_concave = mv["constraint_concave"]
+        else:
+            self._constraint_lower = -np.inf
+            self._constraint_upper = np.inf
+            self._constraint_monotonic = None
+            self._constraint_convex = False
+            self._constraint_concave = False
 
     def optimize(self, fpumz: FloatArray, rho: float) -> FloatArray:
         """Solve the per-feature primal step.
@@ -419,7 +532,7 @@ class _SplineFeature(_Feature):
         fkp1 : (m,) ndarray
             Vector representing this feature's contribution to the response.
         """
-        if self._has_group_lasso or self._has_group_lasso_inf:
+        if self._has_group_lasso or self._has_group_lasso_inf or self._has_constraints:
             self._theta = self._optimize_cvx(fpumz, rho)
         else:
             self._theta = self._optimize_chol(fpumz, rho)
@@ -474,6 +587,25 @@ class _SplineFeature(_Feature):
         if self._has_group_lasso_inf:
             obj = obj + gamma_inf * cvx.norm_inf(N_const @ theta_var)
         constraints = [cvx.Constant(c_vec) @ theta_var == 0]
+
+        if self._has_constraints:
+            # Shape constraints land on the spline value evaluated at the knots
+            # (the natural sequence for cubic regression splines). f_xi[i] is
+            # spline(xi_i); pinning these gives near-global shape control on a
+            # smooth cubic.
+            f_xi = cvx.Constant(self._N_xi) @ theta_var
+            if np.isfinite(self._constraint_lower):
+                constraints.append(f_xi >= self._constraint_lower)
+            if np.isfinite(self._constraint_upper):
+                constraints.append(f_xi <= self._constraint_upper)
+            if self._constraint_monotonic == "increasing":
+                constraints.append(cvx.diff(f_xi) >= 0)
+            elif self._constraint_monotonic == "decreasing":
+                constraints.append(cvx.diff(f_xi) <= 0)
+            if self._constraint_convex:
+                constraints.append(cvx.diff(f_xi, 2) >= 0)
+            if self._constraint_concave:
+                constraints.append(cvx.diff(f_xi, 2) <= 0)
         prob = cvx.Problem(cvx.Minimize(obj), constraints)
         # cvxpy's "Solution may be inaccurate" UserWarning escapes the
         # cvxpy.* module filter (cvxpy attributes it to the caller via
@@ -483,7 +615,16 @@ class _SplineFeature(_Feature):
             warnings.filterwarnings(
                 "ignore", message="Solution may be inaccurate", category=UserWarning
             )
-            prob.solve(verbose=self._verbose, solver=self._solver)
+            try:
+                prob.solve(verbose=self._verbose, solver=self._solver)
+            except cvx.SolverError:
+                # Constrained sub-problems (especially convex / concave shape
+                # constraints across many knots) can hit CLARABEL's numerical
+                # tolerance with a sum_squares + curvature-penalty + many
+                # inequality constraints structure. SCS is a first-order
+                # solver that handles the ill-conditioning, so fall back to it
+                # when the default fails.
+                prob.solve(verbose=self._verbose, solver="SCS")
 
         if prob.status not in (cvx.OPTIMAL, cvx.OPTIMAL_INACCURATE):
             raise RuntimeError(

--- a/tests/test_constraints.py
+++ b/tests/test_constraints.py
@@ -1,0 +1,512 @@
+"""Tests for convex shape constraints on feature coefficients.
+
+Covers ``constraints={...}`` on ``_LinearFeature`` (sign / box on the
+slope), ``_CategoricalFeature`` (box / monotonic / convex / concave on
+the per-level coefficient vector along a user-supplied order), and
+``_SplineFeature`` (box / monotonic / convex / concave on the spline
+evaluated at the knots). For each constraint type, the unconstrained
+fit violates the constraint while the constrained fit satisfies it.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from gamdist import GAM
+from gamdist.categorical_feature import _CategoricalFeature
+from gamdist.linear_feature import _LinearFeature
+from gamdist.spline_feature import _SplineFeature
+
+# ---------------------------------------------------------------------------
+# Linear feature: sign / box on the slope
+# ---------------------------------------------------------------------------
+
+
+def test_linear_unknown_constraint_key_raises() -> None:
+    with pytest.raises(ValueError, match="unknown constraint key"):
+        _LinearFeature(name="x", constraints={"bogus": 1.0})
+
+
+def test_linear_rejects_monotonic() -> None:
+    with pytest.raises(ValueError, match="linear feature does not support"):
+        _LinearFeature(name="x", constraints={"monotonic": "increasing"})
+
+
+def test_linear_sign_invalid_value_raises() -> None:
+    with pytest.raises(ValueError, match="expected 'nonnegative' or 'nonpositive'"):
+        _LinearFeature(name="x", constraints={"sign": "weird"})
+
+
+def test_linear_sign_combined_with_lower_raises() -> None:
+    with pytest.raises(ValueError, match="shorthand"):
+        _LinearFeature(name="x", constraints={"sign": "nonnegative", "lower": -1.0})
+
+
+def test_linear_box_inverted_raises() -> None:
+    with pytest.raises(ValueError, match="exceeds upper"):
+        _LinearFeature(name="x", constraints={"lower": 1.0, "upper": 0.0})
+
+
+def test_linear_sign_nonpositive_clips_positive_unconstrained() -> None:
+    # Data has positive correlation; unconstrained slope > 0; sign=nonpositive
+    # forces m <= 0 so the projection clips to 0.
+    rng = np.random.default_rng(0)
+    n = 100
+    x = rng.normal(size=n)
+    y = 2.0 * (x - x.mean()) + 0.05 * rng.normal(size=n)
+
+    unconstrained = _LinearFeature(name="x")
+    unconstrained.initialize(x)
+    unconstrained.optimize(-y, rho=1.0)
+    assert unconstrained._m > 1.0
+
+    constrained = _LinearFeature(name="x", constraints={"sign": "nonpositive"})
+    constrained.initialize(x)
+    constrained.optimize(-y, rho=1.0)
+    assert constrained._m == 0.0
+
+
+def test_linear_sign_nonnegative_passes_through() -> None:
+    rng = np.random.default_rng(1)
+    n = 100
+    x = rng.normal(size=n)
+    y = 2.0 * (x - x.mean()) + 0.05 * rng.normal(size=n)
+
+    unconstrained = _LinearFeature(name="x")
+    unconstrained.initialize(x)
+    unconstrained.optimize(-y, rho=1.0)
+
+    constrained = _LinearFeature(name="x", constraints={"sign": "nonnegative"})
+    constrained.initialize(x)
+    constrained.optimize(-y, rho=1.0)
+    # The unconstrained minimum is in the feasible region, so the
+    # constrained fit equals the unconstrained fit.
+    assert constrained._m == pytest.approx(unconstrained._m, rel=1e-12, abs=1e-12)
+
+
+def test_linear_box_clips_to_upper() -> None:
+    rng = np.random.default_rng(2)
+    n = 200
+    x = rng.normal(size=n)
+    y = 3.0 * (x - x.mean()) + 0.05 * rng.normal(size=n)
+
+    unconstrained = _LinearFeature(name="x")
+    unconstrained.initialize(x)
+    unconstrained.optimize(-y, rho=1.0)
+    assert unconstrained._m > 1.5
+
+    constrained = _LinearFeature(name="x", constraints={"upper": 1.5})
+    constrained.initialize(x)
+    constrained.optimize(-y, rho=1.0)
+    assert constrained._m == pytest.approx(1.5)
+
+
+def test_linear_box_unconstrained_optimum_inside_box() -> None:
+    rng = np.random.default_rng(3)
+    n = 100
+    x = rng.normal(size=n)
+    y = 0.5 * (x - x.mean()) + 0.05 * rng.normal(size=n)
+
+    unconstrained = _LinearFeature(name="x")
+    unconstrained.initialize(x)
+    unconstrained.optimize(-y, rho=1.0)
+
+    constrained = _LinearFeature(name="x", constraints={"lower": -2.0, "upper": 2.0})
+    constrained.initialize(x)
+    constrained.optimize(-y, rho=1.0)
+    assert constrained._m == pytest.approx(unconstrained._m, rel=1e-12, abs=1e-12)
+
+
+def test_linear_sign_in_gam(tmp_path: Path) -> None:
+    # A signal-then-flip-the-sign scenario: the data wants a positive slope
+    # but the user requires a non-positive one. The fitted slope should be
+    # zero (clipped at the boundary).
+    rng = np.random.default_rng(4)
+    n = 300
+    x = rng.normal(size=n)
+    y = 1.0 * x + 0.1 * rng.normal(size=n)
+    X = pd.DataFrame({"x": x})
+
+    mdl = GAM(family="normal")
+    mdl.add_feature(name="x", type="linear", constraints={"sign": "nonpositive"})
+    mdl.fit(X, y, max_its=40)
+    feat = mdl._features["x"]
+    assert feat._m <= 1e-9  # type: ignore[attr-defined]
+
+
+def test_linear_box_save_load_round_trip(tmp_path: Path) -> None:
+    feat = _LinearFeature(name="x", constraints={"lower": -0.5, "upper": 0.75})
+    feat.initialize(
+        np.arange(5.0),
+        save_flag=True,
+        save_prefix=str(tmp_path / "model"),
+    )
+    feat._m = 0.5
+    feat._b = 0.0
+    feat._save()
+
+    restored = _LinearFeature(load_from_file=feat._filename)
+    assert restored._has_constraints
+    assert restored._lower == pytest.approx(-0.5)
+    assert restored._upper == pytest.approx(0.75)
+
+
+# ---------------------------------------------------------------------------
+# Categorical feature: box / monotonic / convex / concave
+# ---------------------------------------------------------------------------
+
+
+def test_categorical_unknown_constraint_key_raises() -> None:
+    with pytest.raises(ValueError, match="unknown constraint key"):
+        _CategoricalFeature(name="g", constraints={"bogus": 1})
+
+
+def test_categorical_monotonic_invalid_direction_raises() -> None:
+    with pytest.raises(ValueError, match="expected 'increasing' or 'decreasing'"):
+        _CategoricalFeature(
+            name="g", constraints={"monotonic": "weird", "order": ["a", "b"]}
+        )
+
+
+def test_categorical_monotonic_requires_order() -> None:
+    with pytest.raises(ValueError, match="require an 'order' list"):
+        _CategoricalFeature(name="g", constraints={"monotonic": "increasing"})
+
+
+def test_categorical_convex_concave_mutually_exclusive() -> None:
+    with pytest.raises(ValueError, match="mutually exclusive"):
+        _CategoricalFeature(
+            name="g",
+            constraints={"convex": True, "concave": True, "order": ["a", "b", "c"]},
+        )
+
+
+def test_categorical_order_too_short_raises() -> None:
+    with pytest.raises(ValueError, match="at least two categories"):
+        _CategoricalFeature(
+            name="g", constraints={"monotonic": "increasing", "order": ["a"]}
+        )
+
+
+def test_categorical_order_duplicates_raise() -> None:
+    with pytest.raises(ValueError, match="must be unique"):
+        _CategoricalFeature(
+            name="g",
+            constraints={"monotonic": "increasing", "order": ["a", "a", "b"]},
+        )
+
+
+def _fit_categorical(
+    x: np.ndarray,
+    y: np.ndarray,
+    regularization: dict | None = None,
+    constraints: dict | None = None,
+    iters: int = 30,
+) -> _CategoricalFeature:
+    feat = _CategoricalFeature(
+        name="g", regularization=regularization, constraints=constraints
+    )
+    feat.initialize(x)
+    n = len(y)
+    fpumz = -np.asarray(y, dtype=float) * n
+    for _ in range(iters):
+        feat.optimize(fpumz, rho=1.0)
+    return feat
+
+
+def test_categorical_box_clips_extreme_levels() -> None:
+    # Per-level means: a ~ -3, b ~ 0, c ~ +3. Unconstrained fit puts large
+    # positive / negative effects on a and c. A tight box [-1, 1] forces them
+    # to clip while preserving relative ordering.
+    rng = np.random.default_rng(0)
+    n = 600
+    cats = np.array(["a", "b", "c"] * (n // 3))
+    rng.shuffle(cats)
+    means = {"a": -3.0, "b": 0.0, "c": 3.0}
+    y = np.array([means[c] for c in cats]) + 0.1 * rng.normal(size=len(cats))
+
+    unconstrained = _fit_categorical(cats, y)
+    assert unconstrained.p.max() > 2.0
+    assert unconstrained.p.min() < -2.0
+
+    constrained = _fit_categorical(cats, y, constraints={"lower": -1.0, "upper": 1.0})
+    # Box satisfied (with a small numerical slack from CLARABEL).
+    assert constrained.p.max() <= 1.0 + 1e-6
+    assert constrained.p.min() >= -1.0 - 1e-6
+
+
+def test_categorical_monotonic_increasing() -> None:
+    # The data has a non-monotone per-category mean (b > c) so the
+    # unconstrained fit violates the requested ordering. The
+    # monotonic-increasing constraint produces a fit that is non-decreasing
+    # along the supplied order.
+    rng = np.random.default_rng(1)
+    order = ["a", "b", "c", "d"]
+    means = {"a": -1.0, "b": 1.0, "c": 0.5, "d": 2.0}
+    n_per = 200
+    cats = np.repeat(order, n_per)
+    y = np.array([means[c] for c in cats]) + 0.1 * rng.normal(size=len(cats))
+
+    unconstrained = _fit_categorical(cats, y)
+    h = unconstrained._category_hash
+    # Confirm that the unconstrained fit violates the requested ordering.
+    assert unconstrained.p[h["b"]] > unconstrained.p[h["c"]]
+
+    constrained = _fit_categorical(
+        cats, y, constraints={"monotonic": "increasing", "order": order}
+    )
+    h2 = constrained._category_hash
+    seq = [constrained.p[h2[c]] for c in order]
+    diffs = np.diff(seq)
+    assert (diffs >= -1e-6).all()
+
+
+def test_categorical_monotonic_decreasing() -> None:
+    rng = np.random.default_rng(2)
+    order = ["a", "b", "c", "d"]
+    means = {"a": 2.0, "b": 0.5, "c": 1.0, "d": -1.0}
+    n_per = 200
+    cats = np.repeat(order, n_per)
+    y = np.array([means[c] for c in cats]) + 0.1 * rng.normal(size=len(cats))
+
+    constrained = _fit_categorical(
+        cats, y, constraints={"monotonic": "decreasing", "order": order}
+    )
+    h = constrained._category_hash
+    seq = [constrained.p[h[c]] for c in order]
+    diffs = np.diff(seq)
+    assert (diffs <= 1e-6).all()
+
+
+def test_categorical_convex_constraint() -> None:
+    # Unconstrained fit follows a concave shape (peak in the middle); the
+    # convex constraint flips the second-difference sign and forces a U
+    # (or near-linear) profile along the order.
+    rng = np.random.default_rng(3)
+    order = ["a", "b", "c", "d", "e"]
+    # Concave mean profile: arches upward in the middle.
+    means = {"a": 0.0, "b": 1.0, "c": 1.5, "d": 1.0, "e": 0.0}
+    n_per = 200
+    cats = np.repeat(order, n_per)
+    y = np.array([means[c] for c in cats]) + 0.1 * rng.normal(size=len(cats))
+
+    unconstrained = _fit_categorical(cats, y)
+    h = unconstrained._category_hash
+    seq = np.array([unconstrained.p[h[c]] for c in order])
+    # Unconstrained is concave: at least one second-difference is negative.
+    assert np.diff(seq, n=2).min() < -0.1
+
+    constrained = _fit_categorical(
+        cats, y, constraints={"convex": True, "order": order}
+    )
+    h2 = constrained._category_hash
+    seq2 = np.array([constrained.p[h2[c]] for c in order])
+    assert (np.diff(seq2, n=2) >= -1e-6).all()
+
+
+def test_categorical_concave_constraint() -> None:
+    # Mirror of the convex test: convex unconstrained data + concave
+    # constraint forces second differences to be non-positive.
+    rng = np.random.default_rng(4)
+    order = ["a", "b", "c", "d", "e"]
+    # Convex mean profile.
+    means = {"a": 1.5, "b": 0.5, "c": 0.0, "d": 0.5, "e": 1.5}
+    n_per = 200
+    cats = np.repeat(order, n_per)
+    y = np.array([means[c] for c in cats]) + 0.1 * rng.normal(size=len(cats))
+
+    constrained = _fit_categorical(
+        cats, y, constraints={"concave": True, "order": order}
+    )
+    h = constrained._category_hash
+    seq = np.array([constrained.p[h[c]] for c in order])
+    assert (np.diff(seq, n=2) <= 1e-6).all()
+
+
+def test_categorical_constraint_save_load_round_trip(tmp_path: Path) -> None:
+    feat = _CategoricalFeature(
+        name="g",
+        constraints={
+            "monotonic": "increasing",
+            "lower": -2.0,
+            "upper": 2.0,
+            "order": ["a", "b", "c"],
+        },
+    )
+    feat.initialize(
+        np.array(["a", "b", "c", "a", "b"]),
+        save_flag=True,
+        save_prefix=str(tmp_path / "model"),
+    )
+
+    restored = _CategoricalFeature(load_from_file=feat._filename)
+    assert restored._has_constraints
+    assert restored._constraint_lower == pytest.approx(-2.0)
+    assert restored._constraint_upper == pytest.approx(2.0)
+    assert restored._constraint_monotonic == "increasing"
+    assert restored._constraint_order == ["a", "b", "c"]
+
+
+def test_categorical_constraint_in_gam_fit() -> None:
+    rng = np.random.default_rng(5)
+    order = ["lo", "med", "hi"]
+    means = {"lo": -0.5, "med": 1.5, "hi": 0.5}  # not monotone increasing
+    n_per = 300
+    cats = np.repeat(order, n_per)
+    y = np.array([means[c] for c in cats]) + 0.1 * rng.normal(size=len(cats))
+    X = pd.DataFrame({"g": cats})
+
+    mdl = GAM(family="normal")
+    mdl.add_feature(
+        name="g",
+        type="categorical",
+        constraints={"monotonic": "increasing", "order": order},
+    )
+    mdl.fit(X, y, max_its=40)
+    feat = mdl._features["g"]
+    h = feat._category_hash  # type: ignore[attr-defined]
+    p = feat.p  # type: ignore[attr-defined]
+    seq = [p[h[c]] for c in order]
+    assert seq[0] <= seq[1] + 1e-6
+    assert seq[1] <= seq[2] + 1e-6
+
+
+# ---------------------------------------------------------------------------
+# Spline feature: box / monotonic / convex / concave
+# ---------------------------------------------------------------------------
+
+
+def test_spline_unknown_constraint_key_raises() -> None:
+    with pytest.raises(ValueError, match="unknown constraint key"):
+        _SplineFeature(name="x", constraints={"bogus": 1})
+
+
+def test_spline_monotonic_invalid_direction_raises() -> None:
+    with pytest.raises(ValueError, match="expected 'increasing' or 'decreasing'"):
+        _SplineFeature(name="x", constraints={"monotonic": "sideways"})
+
+
+def test_spline_convex_concave_mutually_exclusive() -> None:
+    with pytest.raises(ValueError, match="mutually exclusive"):
+        _SplineFeature(name="x", constraints={"convex": True, "concave": True})
+
+
+def _gam_fit_spline(
+    x: np.ndarray,
+    y: np.ndarray,
+    constraints: dict | None = None,
+    rel_dof: float = 6.0,
+) -> _SplineFeature:
+    X = pd.DataFrame({"x": x})
+    mdl = GAM(family="normal")
+    mdl.add_feature(name="x", type="spline", rel_dof=rel_dof, constraints=constraints)
+    mdl.fit(X, y, max_its=60)
+    return mdl._features["x"]  # type: ignore[return-value]
+
+
+def test_spline_monotonic_increasing() -> None:
+    # Full sine cycle on [0, 1]: clearly non-monotone. Increasing constraint
+    # produces a non-decreasing fit at the knots.
+    rng = np.random.default_rng(0)
+    n = 300
+    x = np.sort(rng.uniform(0.0, 1.0, size=n))
+    y = np.sin(2.0 * np.pi * x) + 0.1 * rng.normal(size=n)
+
+    unconstrained = _gam_fit_spline(x, y)
+    f_xi = unconstrained._N_xi @ unconstrained._theta
+    assert (np.diff(f_xi) < 0).any()
+
+    constrained = _gam_fit_spline(x, y, constraints={"monotonic": "increasing"})
+    f_xi_c = constrained._N_xi @ constrained._theta
+    assert (np.diff(f_xi_c) >= -1e-4).all()
+
+
+def test_spline_monotonic_decreasing() -> None:
+    rng = np.random.default_rng(1)
+    n = 300
+    x = np.sort(rng.uniform(0.0, 1.0, size=n))
+    y = np.cos(2.0 * np.pi * x) + 0.1 * rng.normal(size=n)
+
+    constrained = _gam_fit_spline(x, y, constraints={"monotonic": "decreasing"})
+    f_xi = constrained._N_xi @ constrained._theta
+    assert (np.diff(f_xi) <= 1e-4).all()
+
+
+def test_spline_convex_constraint() -> None:
+    # Concave true mean -> convex constraint flips the curvature at the knots.
+    rng = np.random.default_rng(2)
+    n = 400
+    x = np.sort(rng.uniform(-1.0, 1.0, size=n))
+    y = -(x**2) + 0.05 * rng.normal(size=n)
+
+    unconstrained = _gam_fit_spline(x, y)
+    f_xi = unconstrained._N_xi @ unconstrained._theta
+    assert np.diff(f_xi, n=2).min() < -0.01
+
+    constrained = _gam_fit_spline(x, y, constraints={"convex": True})
+    f_xi_c = constrained._N_xi @ constrained._theta
+    assert (np.diff(f_xi_c, n=2) >= -1e-4).all()
+
+
+def test_spline_concave_constraint() -> None:
+    rng = np.random.default_rng(3)
+    n = 400
+    x = np.sort(rng.uniform(-1.0, 1.0, size=n))
+    y = (x**2) + 0.05 * rng.normal(size=n)
+
+    constrained = _gam_fit_spline(x, y, constraints={"concave": True})
+    f_xi = constrained._N_xi @ constrained._theta
+    assert (np.diff(f_xi, n=2) <= 1e-4).all()
+
+
+def test_spline_box_constraint() -> None:
+    # Strong full sine on [-1, 1] with amplitude 2: an unconstrained fit
+    # exceeds +/-1; box at +/-0.5 forces the spline values at the knots to
+    # stay inside the band.
+    rng = np.random.default_rng(4)
+    n = 400
+    x = np.sort(rng.uniform(-1.0, 1.0, size=n))
+    y = 2.0 * np.sin(2.0 * np.pi * x) + 0.05 * rng.normal(size=n)
+
+    unconstrained = _gam_fit_spline(x, y)
+    f_xi = unconstrained._N_xi @ unconstrained._theta
+    assert f_xi.max() > 1.0
+    assert f_xi.min() < -1.0
+
+    constrained = _gam_fit_spline(x, y, constraints={"lower": -0.5, "upper": 0.5})
+    f_xi_c = constrained._N_xi @ constrained._theta
+    assert f_xi_c.max() <= 0.5 + 1e-4
+    assert f_xi_c.min() >= -0.5 - 1e-4
+
+
+def test_spline_constraint_save_load_round_trip(tmp_path: Path) -> None:
+    feat = _SplineFeature(
+        name="x", constraints={"monotonic": "increasing", "upper": 5.0}
+    )
+    feat.initialize(
+        np.linspace(0.0, 1.0, 50),
+        save_flag=True,
+        save_prefix=str(tmp_path / "model"),
+    )
+    restored = _SplineFeature(load_from_file=feat._filename)
+    assert restored._has_constraints
+    assert restored._constraint_monotonic == "increasing"
+    assert restored._constraint_upper == pytest.approx(5.0)
+    assert np.isfinite(restored._N_xi).all()
+
+
+def test_spline_constraint_in_gam_fit_dose_response() -> None:
+    # Classic dose-response: noisy realisation of a triangle wave that's
+    # non-monotonic; the increasing constraint produces a monotone fit.
+    rng = np.random.default_rng(6)
+    n = 300
+    x = np.sort(rng.uniform(0.0, 1.0, size=n))
+    y = np.where(x < 0.5, x, 1.0 - x) + 0.05 * rng.normal(size=n)
+
+    feat = _gam_fit_spline(x, y, constraints={"monotonic": "increasing"})
+    f_xi = feat._N_xi @ feat._theta
+    assert (np.diff(f_xi) >= -1e-4).all()


### PR DESCRIPTION
Adds a `constraints={...}` keyword to GAM.add_feature and to each
feature class. Sign / box constraints land on linear features (closed-
form clip), while monotonic / convex / concave / box land in the
existing cvxpy programs for categorical and spline features. Spline
constraints apply at the knots; the optimizer falls back to SCS when
CLARABEL hits numerical tolerances on dense knot grids with many active
inequality constraints.

https://claude.ai/code/session_01EqHbX8JEYKSU6w5kxqPGT8