### PR TITLE
Add adaptive (weighted) lasso wrapper (closes #31)

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,40 @@
+2026-04-26 : Adaptive (weighted) lasso wrapper
+- Added `fit_adaptive_lasso(gam, X, y, *, gamma=1.0, eps=1e-6, **fit_kwargs)`
+  as a top-level helper exported from the `gamdist` package. It runs the
+  standard two-stage adaptive lasso of Zou (2006): fit `gam` once with
+  the user-configured L1 penalty to get pilot coefficients, rewrite each
+  L1-regularized feature's per-coefficient weight to
+  `base / (|pilot - prior| + eps) ** gamma`, then refit. Both stages are
+  ordinary weighted-L1 fits at fixed weights, so each subproblem stays
+  convex (CLAUDE.md North Star). Closes #31.
+- _LinearFeature: gained `_apply_adaptive_l1(gamma, eps)` that rewrites
+  the scalar `_coef1` from the pilot slope `_m`. The next `initialize()`
+  call rescales it by the model's `smoothing` into `_lambda1`.
+- _CategoricalFeature: gained `_apply_adaptive_l1(gamma, eps)` that
+  rewrites `_coef1` as a per-category dict, naturally exercising the
+  existing dict-coef support in `_compute_lambda`. When the user
+  configured a prior, the adaptive deviation is `|p_c - prior_c|` and
+  only categories named in the prior dict are rewritten; categories
+  excluded by an explicit dict-form base coefficient stay at zero.
+- _CategoricalFeature: made `initialize()` idempotent with respect to
+  the prior dict-to-vector conversion (the second stage of adaptive
+  lasso would otherwise call `.items()` on the previously-converted
+  ndarray and crash). The user-supplied prior keys are now persisted in
+  a separate `_prior_keys` set so `_compute_lambda` can apply uniform
+  base-coef penalties only to the originally-named categories on
+  re-initialize. Older pickles default `_prior_keys` to the categories
+  with non-zero `_prior` values for backward compatibility.
+- Tests in `tests/test_adaptive_lasso.py` cover: parameter validation
+  (gamma <= 0, eps <= 0, no L1 features), the per-feature
+  `_apply_adaptive_l1` behavior (linear scalar rewrite, no-op when no
+  L1 / zero base coef, categorical dict rewrite, dict-base-coef
+  category exclusion, prior-deviation logic and prior-key filtering),
+  end-to-end recovery on a sparse linear-features fixture (adaptive
+  shrinks noise harder than plain L1 and is closer to the true signal),
+  noise features driven essentially to zero with gamma=1, and a
+  five-level categorical with two active levels recovering sparsity
+  better than plain L1.
+
 2026-04-26 : Convex shape constraints on feature coefficients
 - Added a `constraints={...}` keyword to `GAM.add_feature` and to each
   feature class. Supported keys: `sign` (`"nonnegative"` /

--- a/gamdist/__init__.py
+++ b/gamdist/__init__.py
@@ -3,8 +3,8 @@
 from __future__ import annotations
 
 from .feature import _Feature
-from .gamdist import GAM
+from .gamdist import GAM, fit_adaptive_lasso
 from .spline_feature import SplineError
 
-__all__ = ["GAM", "SplineError", "_Feature"]
+__all__ = ["GAM", "SplineError", "_Feature", "fit_adaptive_lasso"]
 __version__ = "0.2.0"

--- a/gamdist/categorical_feature.py
+++ b/gamdist/categorical_feature.py
@@ -108,6 +108,7 @@ class _CategoricalFeature(_Feature):
         self._has_group_lasso = False
         self._has_group_lasso_inf = False
         self._has_prior = False
+        self._prior_keys: set[Any] | None = None
         self._coef1: float | dict[Any, float] = 0.0
         self._coef2: float | dict[Any, float] = 0.0
         self._coef_huber: float | dict[Any, float] = 0.0
@@ -225,6 +226,14 @@ class _CategoricalFeature(_Feature):
             if (self._has_l1 or self._has_l2) and "prior" in regularization:
                 self._has_prior = True
                 self._prior: Any = regularization["prior"]
+                # Track the user-supplied prior keys separately so
+                # `_compute_lambda` can apply uniform-coef penalties only to
+                # the categories the user named, even after `initialize`
+                # rewrites `self._prior` as a dense vector. Without this,
+                # a second `initialize()` call (e.g. the refit stage of
+                # adaptive lasso) sees `self._prior` as an ndarray and the
+                # membership / iteration logic below misbehaves.
+                self._prior_keys = set(regularization["prior"].keys())
 
         self._has_constraints = False
         self._constraint_lower: float = -np.inf
@@ -413,7 +422,15 @@ class _CategoricalFeature(_Feature):
                             float(value) * smoothing
                         )
 
-        if (self._has_l1 or self._has_l2) and self._has_prior:
+        # Idempotent: a second `initialize()` call (for example, the
+        # adaptive-lasso refit) would otherwise try to .items() an
+        # ndarray. The original prior keys live in `_prior_keys`; we
+        # just keep the existing vector when `_prior` is already one.
+        if (
+            (self._has_l1 or self._has_l2)
+            and self._has_prior
+            and isinstance(self._prior, dict)
+        ):
             prior_vec = np.zeros(self._num_categories)
             for key, value in self._prior.items():
                 prior_vec[self._category_hash[key]] = value
@@ -455,16 +472,17 @@ class _CategoricalFeature(_Feature):
     ) -> FloatArray:
         """Build the per-category regularization-weight vector."""
         result = np.zeros(self._num_categories)
+        prior_keys = self._prior_keys if self._has_prior else None
         if isinstance(coef, (int, float)):
             scaled = float(coef) * smoothing
-            if self._has_prior:
-                for key in self._prior:
+            if prior_keys is not None:
+                for key in prior_keys:
                     result[self._category_hash[key]] = scaled
             else:
                 result[:] = scaled
         else:
             for key, value in coef.items():
-                if self._has_prior and key not in self._prior:
+                if prior_keys is not None and key not in prior_keys:
                     continue
                 result[self._category_hash[key]] = float(value) * smoothing
         return result
@@ -522,6 +540,8 @@ class _CategoricalFeature(_Feature):
             mv["lambda_huber_vec"] = self._lambda_huber_vec
         if self._has_prior:
             mv["prior"] = self._prior
+            if self._prior_keys is not None:
+                mv["prior_keys"] = self._prior_keys
         if self._has_constraints:
             mv["has_constraints"] = True
             mv["constraint_lower"] = self._constraint_lower
@@ -595,6 +615,18 @@ class _CategoricalFeature(_Feature):
         self._has_prior = mv["has_prior"]
         if self._has_prior:
             self._prior = mv["prior"]
+            # prior_keys persisted from a later release; older pickles only
+            # have the vector form, so reconstruct from non-zero entries.
+            if "prior_keys" in mv:
+                self._prior_keys = mv["prior_keys"]
+            else:
+                self._prior_keys = {
+                    cat
+                    for cat, idx in self._category_hash.items()
+                    if self._prior[idx] != 0.0
+                }
+        else:
+            self._prior_keys = None
         # has_constraints added later; default to False for older pickles.
         self._has_constraints = mv.get("has_constraints", False)
         if self._has_constraints:
@@ -792,6 +824,40 @@ class _CategoricalFeature(_Feature):
         """Compute this feature's contribution to the dual residual tolerance."""
         Aty = self._compute_Atz(y)
         return float(Aty.dot(Aty))
+
+    def _apply_adaptive_l1(self, gamma: float, eps: float) -> bool:
+        """Rewrite ``self._coef1`` as adaptive-lasso weights from the pilot.
+
+        For each category that the original L1 configuration touched, the
+        new per-category coefficient is ``base_c / (|p_c - prior_c| + eps)
+        ** gamma``. Categories that the user did not penalize (``base_c
+        == 0``) stay at zero. Returns True iff this feature contributed an
+        L1 penalty that was rewritten; the caller uses that to validate
+        that adaptive-lasso has something to do.
+        """
+        if not self._has_l1:
+            return False
+        base = self._coef1
+        if self._has_prior:
+            prior_vec = self._prior
+        else:
+            prior_vec = np.zeros(self._num_categories)
+        new_coef: dict[Any, float] = {}
+        rewrote = False
+        for cat, idx in self._category_hash.items():
+            if isinstance(base, dict):
+                base_c = float(base.get(cat, 0.0))
+            else:
+                base_c = float(base)
+            if base_c == 0.0:
+                continue
+            if self._prior_keys is not None and cat not in self._prior_keys:
+                continue
+            deviation = abs(float(self.p[idx]) - float(prior_vec[idx]))
+            new_coef[cat] = base_c / (deviation + eps) ** gamma
+            rewrote = True
+        self._coef1 = new_coef
+        return rewrote
 
     def num_params(self) -> int:
         """Number of parameters in this feature."""

--- a/gamdist/gamdist.py
+++ b/gamdist/gamdist.py
@@ -2482,3 +2482,85 @@ class GAM:
 
         for _name, feature in self._features.items():
             print(str(feature))
+
+
+def fit_adaptive_lasso(
+    gam: GAM,
+    X: pd.DataFrame,
+    y: npt.NDArray[Any],
+    *,
+    gamma: float = 1.0,
+    eps: float = 1e-6,
+    **fit_kwargs: Any,
+) -> GAM:
+    """Fit ``gam`` via the two-stage adaptive lasso (Zou, 2006).
+
+    The first stage fits ``gam`` to ``(X, y)`` using whatever L1
+    regularization the user configured on each feature -- producing a
+    pilot estimate of every coefficient. The second stage rewrites each
+    L1-regularized feature's per-coefficient L1 weight to ``base /
+    (|pilot| + eps) ** gamma`` and refits. Coefficients with large pilot
+    magnitudes are penalized less; tiny pilots (likely noise) are
+    penalized more, recovering the "oracle" sparsity pattern with less
+    bias on the truly active coefficients than plain L1.
+
+    Both stages are convex (they are ordinary weighted-L1 fits at fixed
+    weights), so this is just a thin wrapper over two ``GAM.fit`` calls.
+
+    Parameters
+    ----------
+    gam : GAM
+        Fully configured but not-yet-fit GAM. At least one feature must
+        carry an ``regularization={"l1": {"coef": ...}}`` configuration;
+        other features and other regularizers (l2, group_lasso, ...)
+        ride along untouched. The same ``gam`` object is mutated in
+        place and returned.
+    X, y : data
+        Forwarded to both ``gam.fit`` calls.
+    gamma : float
+        Adaptive-lasso exponent (typically 1.0). Larger ``gamma`` makes
+        the second-stage weights swing harder around the pilot
+        magnitudes.
+    eps : float
+        Stabilizer added to the pilot magnitude before exponentiation,
+        so a pilot of exactly zero produces a finite (though large)
+        second-stage weight rather than a divide-by-zero.
+    **fit_kwargs
+        Forwarded to both ``gam.fit`` calls. Both stages see the same
+        ``smoothing``, ``max_its``, ``weights``, etc.
+
+    Returns
+    -------
+    gam : GAM
+        The same model, now fit with adaptive L1 weights.
+    """
+    if gamma <= 0.0:
+        raise ValueError(f"gamma must be positive; got {gamma}.")
+    if eps <= 0.0:
+        raise ValueError(f"eps must be positive; got {eps}.")
+
+    has_l1 = any(getattr(f, "_has_l1", False) for f in gam._features.values())
+    if not has_l1:
+        raise ValueError(
+            "fit_adaptive_lasso requires at least one feature with "
+            'regularization={"l1": ...}; without an L1 term to reweight, '
+            "the second stage is identical to the first."
+        )
+
+    gam.fit(X, y, **fit_kwargs)
+
+    rewrote_any = False
+    for feature in gam._features.values():
+        apply = getattr(feature, "_apply_adaptive_l1", None)
+        if apply is None:
+            continue
+        if apply(gamma, eps):
+            rewrote_any = True
+    if not rewrote_any:
+        # Defensive: should be impossible given the has_l1 guard above,
+        # but feature subclasses without `_apply_adaptive_l1` would land
+        # here. Skip the second fit rather than producing identical output.
+        return gam
+
+    gam.fit(X, y, **fit_kwargs)
+    return gam

--- a/gamdist/linear_feature.py
+++ b/gamdist/linear_feature.py
@@ -518,6 +518,20 @@ class _LinearFeature(_Feature):
             1.0 + self._xmean * self._xmean
         ) * ybar * ybar
 
+    def _apply_adaptive_l1(self, gamma: float, eps: float) -> bool:
+        """Rewrite ``self._coef1`` as the adaptive-lasso weight from the pilot.
+
+        With a single slope ``m``, the new L1 coefficient is
+        ``base / (|m| + eps) ** gamma``. The next ``initialize()`` call
+        will rescale this by ``smoothing`` into ``self._lambda1``.
+        Returns True iff the feature has a non-zero L1 base coefficient.
+        """
+        if not self._has_l1 or self._coef1 == 0.0:
+            return False
+        pilot_dev = abs(float(self._m))
+        self._coef1 = float(self._coef1) / (pilot_dev + eps) ** gamma
+        return True
+
     def num_params(self) -> int:
         """Number of parameters in this feature."""
         return 1

--- a/tests/test_adaptive_lasso.py
+++ b/tests/test_adaptive_lasso.py
@@ -1,0 +1,220 @@
+"""Tests for the two-stage adaptive lasso wrapper.
+
+Adaptive lasso (Zou 2006) refits a model after rewriting each L1
+coefficient to ``base / (|pilot| + eps) ** gamma``. Coefficients with
+large pilot magnitudes are penalized less; tiny pilots are penalized
+more. The expected behavior on a sparse-truth signal is:
+
+  * Noise features shrink harder than they would under plain L1.
+  * Signal features are biased less toward zero than they would be under
+    plain L1, recovering the pilot-driven "oracle" estimate.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from gamdist import GAM, fit_adaptive_lasso
+from gamdist.categorical_feature import _CategoricalFeature
+from gamdist.linear_feature import _LinearFeature
+
+
+def _build_linear_gam(coef: float) -> GAM:
+    mdl = GAM(family="normal")
+    mdl.add_feature(name="signal", type="linear", regularization={"l1": {"coef": coef}})
+    mdl.add_feature(name="noise1", type="linear", regularization={"l1": {"coef": coef}})
+    mdl.add_feature(name="noise2", type="linear", regularization={"l1": {"coef": coef}})
+    return mdl
+
+
+def _make_sparse_linear_data(
+    seed: int = 0, n: int = 400
+) -> tuple[pd.DataFrame, np.ndarray]:
+    rng = np.random.default_rng(seed)
+    signal = rng.normal(size=n)
+    noise1 = rng.normal(size=n)
+    noise2 = rng.normal(size=n)
+    y = 2.0 * (signal - signal.mean()) + 0.1 * rng.normal(size=n)
+    X = pd.DataFrame({"signal": signal, "noise1": noise1, "noise2": noise2})
+    return X, y
+
+
+def test_validates_gamma_and_eps() -> None:
+    X, y = _make_sparse_linear_data()
+    mdl = _build_linear_gam(coef=0.3)
+    with pytest.raises(ValueError, match="gamma must be positive"):
+        fit_adaptive_lasso(mdl, X, y, gamma=0.0, max_its=5)
+    with pytest.raises(ValueError, match="gamma must be positive"):
+        fit_adaptive_lasso(mdl, X, y, gamma=-1.0, max_its=5)
+    with pytest.raises(ValueError, match="eps must be positive"):
+        fit_adaptive_lasso(mdl, X, y, eps=0.0, max_its=5)
+
+
+def test_requires_at_least_one_l1_feature() -> None:
+    X, y = _make_sparse_linear_data()
+    mdl = GAM(family="normal")
+    mdl.add_feature(name="signal", type="linear")
+    mdl.add_feature(name="noise1", type="linear", regularization={"l2": {"coef": 0.5}})
+    with pytest.raises(ValueError, match="requires at least one feature with"):
+        fit_adaptive_lasso(mdl, pd.concat([X[["signal", "noise1"]]], axis=1), y)
+
+
+def test_linear_apply_adaptive_l1_rewrites_coef1() -> None:
+    feat = _LinearFeature(name="x", regularization={"l1": {"coef": 0.3}})
+    feat.initialize(np.arange(10.0))
+    feat._m = 0.5
+    rewrote = feat._apply_adaptive_l1(gamma=1.0, eps=1e-6)
+    assert rewrote
+    assert feat._coef1 == pytest.approx(0.3 / (0.5 + 1e-6))
+
+
+def test_linear_apply_adaptive_l1_skips_when_no_l1() -> None:
+    feat = _LinearFeature(name="x", regularization={"l2": {"coef": 0.5}})
+    feat.initialize(np.arange(10.0))
+    feat._m = 0.5
+    assert feat._apply_adaptive_l1(gamma=1.0, eps=1e-6) is False
+
+
+def test_linear_apply_adaptive_l1_skips_zero_base_coef() -> None:
+    feat = _LinearFeature(name="x", regularization={"l1": {"coef": 0.0}})
+    feat.initialize(np.arange(10.0))
+    feat._m = 0.5
+    assert feat._apply_adaptive_l1(gamma=1.0, eps=1e-6) is False
+
+
+def test_categorical_apply_adaptive_l1_uses_dict_form() -> None:
+    feat = _CategoricalFeature(name="g", regularization={"l1": {"coef": 0.5}})
+    feat.initialize(np.array(["a", "b", "c"]))
+    a, b, c = (feat._category_hash[k] for k in ("a", "b", "c"))
+    feat.p = np.zeros(3)
+    feat.p[a] = 1.5
+    feat.p[b] = 0.1
+    feat.p[c] = -0.05
+    rewrote = feat._apply_adaptive_l1(gamma=1.0, eps=1e-6)
+    assert rewrote
+    assert isinstance(feat._coef1, dict)
+    # Larger pilot magnitude => smaller penalty
+    assert feat._coef1["a"] < feat._coef1["b"]
+    assert feat._coef1["a"] < feat._coef1["c"]
+    assert feat._coef1["a"] == pytest.approx(0.5 / (1.5 + 1e-6))
+    assert feat._coef1["b"] == pytest.approx(0.5 / (0.1 + 1e-6))
+
+
+def test_categorical_apply_adaptive_l1_with_dict_base_only_touches_listed_cats() -> (
+    None
+):
+    feat = _CategoricalFeature(
+        name="g", regularization={"l1": {"coef": {"a": 0.4, "b": 0.6}}}
+    )
+    feat.initialize(np.array(["a", "b", "c"]))
+    a, b, c = (feat._category_hash[k] for k in ("a", "b", "c"))
+    feat.p = np.zeros(3)
+    feat.p[a] = 0.5
+    feat.p[b] = 1.0
+    feat.p[c] = 2.0
+    feat._apply_adaptive_l1(gamma=1.0, eps=1e-6)
+    assert isinstance(feat._coef1, dict)
+    assert "c" not in feat._coef1
+    assert feat._coef1["a"] == pytest.approx(0.4 / (0.5 + 1e-6))
+    assert feat._coef1["b"] == pytest.approx(0.6 / (1.0 + 1e-6))
+
+
+def test_categorical_apply_adaptive_l1_with_prior_uses_deviation() -> None:
+    feat = _CategoricalFeature(
+        name="g",
+        regularization={"l1": {"coef": 0.5}, "prior": {"a": 1.0, "b": -1.0}},
+    )
+    feat.initialize(np.array(["a", "b", "c"]))
+    a, b, c = (feat._category_hash[k] for k in ("a", "b", "c"))
+    feat.p = np.zeros(3)
+    feat.p[a] = 1.2  # deviation 0.2 from prior 1.0
+    feat.p[b] = -0.5  # deviation 0.5 from prior -1.0
+    feat.p[c] = 5.0  # not in prior keys; should be skipped
+    feat._apply_adaptive_l1(gamma=1.0, eps=1e-6)
+    assert isinstance(feat._coef1, dict)
+    # c was not in prior keys -> excluded from new coef1
+    assert "c" not in feat._coef1
+    assert feat._coef1["a"] == pytest.approx(0.5 / (0.2 + 1e-6))
+    assert feat._coef1["b"] == pytest.approx(0.5 / (0.5 + 1e-6))
+
+
+def test_linear_adaptive_lasso_shrinks_noise_more_than_plain() -> None:
+    """End-to-end: adaptive lasso shrinks noise and protects signal more
+    than plain lasso at the same base coefficient."""
+    X, y = _make_sparse_linear_data(seed=2, n=400)
+
+    plain = _build_linear_gam(coef=0.3)
+    plain.fit(X, y, max_its=80)
+    plain_signal = abs(plain._features["signal"]._m)  # type: ignore[attr-defined]
+    plain_noise1 = abs(plain._features["noise1"]._m)  # type: ignore[attr-defined]
+    plain_noise2 = abs(plain._features["noise2"]._m)  # type: ignore[attr-defined]
+
+    adapted = _build_linear_gam(coef=0.3)
+    fit_adaptive_lasso(adapted, X, y, gamma=1.0, eps=1e-3, max_its=80)
+    adapt_signal = abs(adapted._features["signal"]._m)  # type: ignore[attr-defined]
+    adapt_noise1 = abs(adapted._features["noise1"]._m)  # type: ignore[attr-defined]
+    adapt_noise2 = abs(adapted._features["noise2"]._m)  # type: ignore[attr-defined]
+
+    # Noise shrinks at least as much under adaptive
+    assert adapt_noise1 <= plain_noise1 + 1e-9
+    assert adapt_noise2 <= plain_noise2 + 1e-9
+    # Signal is biased less under adaptive (i.e., closer to true 2.0)
+    true_signal = 2.0
+    assert abs(adapt_signal - true_signal) < abs(plain_signal - true_signal)
+
+
+def test_linear_adaptive_lasso_drives_pure_noise_features_to_zero() -> None:
+    """With gamma=1 and a small eps, noise features whose pilot is already
+    near zero should round-trip to essentially zero in stage 2."""
+    X, y = _make_sparse_linear_data(seed=5, n=300)
+    mdl = _build_linear_gam(coef=0.4)
+    fit_adaptive_lasso(mdl, X, y, gamma=1.0, eps=1e-3, max_its=80)
+    # Signal should remain substantial; both noise features should vanish.
+    signal_m = abs(mdl._features["signal"]._m)  # type: ignore[attr-defined]
+    noise1_m = abs(mdl._features["noise1"]._m)  # type: ignore[attr-defined]
+    noise2_m = abs(mdl._features["noise2"]._m)  # type: ignore[attr-defined]
+    assert signal_m > 1.0
+    assert noise1_m == pytest.approx(0.0, abs=1e-6)
+    assert noise2_m == pytest.approx(0.0, abs=1e-6)
+
+
+def test_categorical_adaptive_lasso_recovers_sparse_levels() -> None:
+    """Categorical with 5 levels where only 2 carry non-zero true effects.
+    Adaptive lasso should shrink the three null levels harder than plain
+    lasso, while keeping the active levels close to truth."""
+    rng = np.random.default_rng(7)
+    n = 800
+    cats = rng.choice(["a", "b", "c", "d", "e"], size=n)
+    true_effects = {"a": 0.0, "b": 0.0, "c": 0.0, "d": 1.0, "e": -1.0}
+    eta = np.array([true_effects[c] for c in cats]) + 0.2 * rng.normal(size=n)
+    X = pd.DataFrame({"g": cats})
+
+    plain = GAM(family="normal")
+    plain.add_feature(
+        name="g", type="categorical", regularization={"l1": {"coef": 0.5}}
+    )
+    plain.fit(X, eta, max_its=80)
+    plain_p = plain._features["g"].p.copy()  # type: ignore[attr-defined]
+    plain_hash = plain._features["g"]._category_hash  # type: ignore[attr-defined]
+
+    adapted = GAM(family="normal")
+    adapted.add_feature(
+        name="g", type="categorical", regularization={"l1": {"coef": 0.5}}
+    )
+    fit_adaptive_lasso(adapted, X, eta, gamma=1.0, eps=1e-3, max_its=80)
+    adapt_p = adapted._features["g"].p  # type: ignore[attr-defined]
+    adapt_hash = adapted._features["g"]._category_hash  # type: ignore[attr-defined]
+
+    null_cats = ["a", "b", "c"]
+    plain_null_norm = sum(abs(plain_p[plain_hash[c]]) for c in null_cats)
+    adapt_null_norm = sum(abs(adapt_p[adapt_hash[c]]) for c in null_cats)
+    # Adaptive lasso's stage-2 weights are huge for tiny pilots, so the
+    # null categories shrink harder.
+    assert adapt_null_norm < plain_null_norm
+
+    # Active categories still close to truth (and zero-sum is enforced
+    # globally by the categorical optimizer).
+    assert adapt_p[adapt_hash["d"]] > 0.7
+    assert adapt_p[adapt_hash["e"]] < -0.7


### PR DESCRIPTION
Two-stage adaptive lasso (Zou 2006): fit once with the user-configured
L1 penalty, then refit with each L1 coefficient rewritten as
base / (|pilot - prior| + eps) ** gamma. Both stages are ordinary
weighted-L1 fits at fixed weights, so each subproblem stays convex.

- gamdist.fit_adaptive_lasso wraps two GAM.fit calls; exported from
  the package.
- _LinearFeature._apply_adaptive_l1 rewrites the scalar _coef1 from
  the pilot slope.
- _CategoricalFeature._apply_adaptive_l1 rewrites _coef1 as a
  per-category dict (exercising the existing dict-coef path) and
  honors the prior keys / dict-form base coefficient when present.
- _CategoricalFeature.initialize is now idempotent w.r.t. the prior
  dict-to-vector conversion (the second fit would otherwise crash on
  .items() of an ndarray). User-supplied prior keys are tracked
  separately in _prior_keys for re-init correctness; older pickles
  reconstruct from non-zero entries.