### PR TITLE
Add MultiTaskGAM for joint multi-outcome fitting (first slice of #39)

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,65 @@ to get the smooth-shrinkage variant: a quadratic penalty
 `L`) that pulls neighboring coefficients *toward* each other instead
 of clustering them to identical values.
 
+### Multi-task: one feature set, multiple outcomes
+
+`MultiTaskGAM` fits K outcomes jointly under a shared feature set, with
+each task picking its own family and link and an optional **coupling
+regularizer** that ties the K coefficients of each feature together.
+The headline use case: identify a feature set that's simultaneously
+predictive of every outcome — not a feature set that's brilliant on
+some outcomes and useless on others.
+
+```python
+import numpy as np
+import pandas as pd
+from gamdist import MultiTaskGAM
+
+rng = np.random.default_rng(1)
+n = 400
+signal = rng.normal(size=n)
+noise = rng.normal(size=n)
+X = pd.DataFrame({"signal": signal, "noise": noise})
+
+y_continuous = 1.5 * signal + 0.1 * rng.normal(size=n)
+y_binary = (
+    rng.uniform(size=n) < 1.0 / (1.0 + np.exp(-0.8 * signal))
+).astype(float)
+
+mdl = MultiTaskGAM(families=["normal", "binomial"])
+mdl.add_feature(
+    "signal",
+    type="linear",
+    regularization={"group_lasso_across_tasks": {"coef": 0.5}},
+)
+mdl.add_feature(
+    "noise",
+    type="linear",
+    regularization={"group_lasso_across_tasks": {"coef": 0.5}},
+)
+mdl.fit([X, X], [y_continuous, y_binary])
+
+yhats = mdl.predict([X, X])
+# yhats[0] is the continuous task's mean; yhats[1] is task 2's
+# probability in (0, 1). With this λ the `noise` feature has been
+# dropped from BOTH tasks simultaneously — group-lasso across tasks
+# zeros the entire K-vector of slopes at once, not each task's slope
+# independently. That's the multi-task variable-selection story you
+# can't get from running K independent GAMs.
+```
+
+Tasks may have different `(family, link)` pairs, different observation
+counts, even different feature data per task — they only have to agree
+on the *names* of the features they share. The per-task ADMM splits
+stay independent except for the cross-task penalty inside each shared
+feature, so the seam principle (CLAUDE.md) carries over without
+changes to the orchestrator.
+
+Other coupling penalties (trace / nuclear norm, network-on-tasks,
+hierarchical pooling) and other convex ways to combine the per-task
+losses (weighted sum, log-sum-exp, minimax / CVaR) are tracked as
+follow-ups in [issue #39][issue39] and [issue #71][issue71].
+
 ## Development
 
 ```bash
@@ -171,3 +230,5 @@ Every per-component subproblem must be convex.
 [gamadmm]: https://stanford.edu/~boyd/papers/admm/gam.html
 [uv]: https://github.com/astral-sh/uv
 [issue19]: https://github.com/rwilson4/gamdist/issues/19
+[issue39]: https://github.com/rwilson4/gamdist/issues/39
+[issue71]: https://github.com/rwilson4/gamdist/issues/71

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,64 @@
+2026-04-27 : Multi-task GAM (joint fit across K outcomes with convex coupling)
+- Added MultiTaskGAM and a new feature module gamdist/multi_task_features.py
+  for fitting K supervised-learning tasks jointly under a shared feature set
+  with optional convex cross-task regularization. First slice in the design
+  RFC at issue #39: per-task (family, link), per-task n_k (different lengths
+  allowed), and one coupling penalty -- group-lasso across tasks on a linear
+  feature -- which zeros the feature simultaneously across all K tasks once
+  lambda is large enough. Coupling lives entirely inside the feature; the
+  orchestrator never sees a penalty coefficient (CLAUDE.md seam principle).
+- gamdist/multi_task_gamdist.py: MultiTaskGAM(families, links=None,
+  dispersions=None, name=None) holds K parallel ADMM-state lists (f_bar,
+  z_bar, u, offset, residual histories). add_feature(name, type='linear',
+  ...) is restricted to linear features in this slice; categorical/spline
+  can be added by analogy. fit([X_1,...,X_K], [y_1,...,y_K], weights=None,
+  smoothing=1.0, max_its=100) runs K-coupled ADMM: per iteration, each
+  multi-task feature's optimize_multi receives the K fpumz vectors and
+  returns K contributions; the proximal step is K independent calls of the
+  existing (family_k, link_k) prox via _optimize_task. Convergence requires
+  every task's primal/dual residual to drop below its own tolerance;
+  prim_res / dual_res accumulate the max across tasks for the trace.
+- gamdist/multi_task_features.py: _MultiTaskFeature ABC adds initialize_multi,
+  optimize_multi, predict_task, compute_dual_tol_task, num_params_task, and
+  dof_task; the single-task ABC methods (initialize / optimize / predict)
+  raise NotImplementedError so the orchestrator distinguishes the two paths
+  unambiguously. _MultiTaskLinearFeature owns one slope per task plus shared
+  data caches; without coupling the K subproblems decouple and reduce to K
+  independent 1-D least-squares solves matching _LinearFeature task-by-task.
+  regularization={"group_lasso_across_tasks": {"coef": lambda}} adds
+  lambda * sqrt(sum_k m_k^2 * xtx_k), the K-task generalization of the
+  single-task linear group-lasso. Closed-form prox in the change of
+  variables eta_k = m_k * sqrt(xtx_k): the penalty becomes lambda * ||eta||_2
+  and the per-task quadratic stays diagonal, so the standard L2
+  group-lasso shrinkage drops out: eta = max(0, 1 - lambda/(rho * ||b||_2)) * b.
+- predict accepts either a single DataFrame (same predictors for every task)
+  or a length-K list (per-task predictors) and returns a length-K list of
+  mean responses; deviance returns a length-K list and reuses the existing
+  per-family deviance math, parameterized by task index.
+- Out of scope for this slice (raise NotImplementedError on call): persistence
+  (save_flag / load_from_file), summary / plot / aic / aicc / gcv / ubre /
+  confidence_intervals, robust covariance, quantile / huber families,
+  covariate classes, the estimate_overdispersion path, and per-feature
+  tasks=[subset] routing. Other coupling penalties (nuclear / trace norm,
+  network lasso on a task graph, hierarchical pooling) are also deferred.
+- Tests in tests/test_multi_task_gam.py cover: feature-level validation
+  (zero tasks, unsupported regularization keys, missing / negative coef),
+  smoothing scaling, huge-lambda zeroing all K slopes simultaneously,
+  lambda=0 decoupling matches per-task OLS closed form, MultiTaskGAM
+  construction (empty / unknown / quantile families, mismatched links
+  length, unsupported (family, link) pair, canonical-link defaults,
+  per-task dispersions), and end-to-end fits: unequal n_k recovery, no-
+  coupling parity with two independently-fit GAMs, group-lasso uniformly
+  zeroing a noise feature in both tasks, mixed normal+identity /
+  binomial+logit fit and predict, predict accepting per-task DataFrames,
+  deviance(X, y) parity with the iterate-based form, predict-before-fit
+  guard, and NotImplementedError on summary / aic / aicc / gcv / ubre /
+  confidence_intervals plus the categorical feature-type rejection.
+  Closes the first slice of #39; follow-up issues to file: other coupling
+  penalties (#39 trace-norm / network-on-tasks / hierarchical pooling),
+  multi-task categorical / spline features, persistence, summary / plot,
+  and tasks=[subset] routing for mixed task-local / shared features.
+
 2026-04-26 : Adaptive (weighted) lasso wrapper
 - Added `fit_adaptive_lasso(gam, X, y, *, gamma=1.0, eps=1e-6, **fit_kwargs)`
   as a top-level helper exported from the `gamdist` package. It runs the

--- a/gamdist/__init__.py
+++ b/gamdist/__init__.py
@@ -4,7 +4,14 @@ from __future__ import annotations
 
 from .feature import _Feature
 from .gamdist import GAM, fit_adaptive_lasso
+from .multi_task_gamdist import MultiTaskGAM
 from .spline_feature import SplineError
 
-__all__ = ["GAM", "SplineError", "_Feature", "fit_adaptive_lasso"]
+__all__ = [
+    "GAM",
+    "MultiTaskGAM",
+    "SplineError",
+    "_Feature",
+    "fit_adaptive_lasso",
+]
 __version__ = "0.2.0"

--- a/gamdist/multi_task_features.py
+++ b/gamdist/multi_task_features.py
@@ -1,0 +1,352 @@
+# Copyright 2017 Match Group, LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you
+# may not use this file except in compliance with the License. You may
+# obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied.  See the License for the specific language governing
+# permissions and limitations under the License.
+#
+# Passing untrusted user input may have unintended consequences. Not
+# designed to consume input from unknown sources (i.e., the public
+# internet).
+#
+# This file has been modified from the original release by Match Group
+# LLC. A description of changes may be found in the change log
+# accompanying this source code.
+
+"""Feature classes that span multiple tasks in a ``MultiTaskGAM``.
+
+A ``_MultiTaskFeature`` owns one set of coefficients shared across the
+K tasks and, optionally, a convex *coupling* regularizer that ties those
+K coefficients together. Coupling lives entirely inside the feature --
+the multi-task orchestrator never sees a penalty coefficient -- so the
+seam principle from CLAUDE.md is preserved.
+
+The first concrete subclass is ``_MultiTaskLinearFeature``: a linear
+contribution ``m_k * (x_k - mean(x_k))`` for each task ``k``. The only
+coupling penalty implemented in this slice is **group-lasso across
+tasks**: ``lambda * sqrt(sum_k m_k^2 * xtx_k)``, the K-task
+generalization of the existing single-task linear group-lasso. With
+``lambda = 0`` the K subproblems decouple and the feature behaves like K
+independent ``_LinearFeature`` instances stitched together.
+"""
+
+from __future__ import annotations
+
+import math
+from collections.abc import Callable
+from typing import Any
+
+import numpy as np
+import numpy.typing as npt
+
+from .feature import _Feature
+
+FloatArray = npt.NDArray[np.float64]
+Transform = Callable[[npt.NDArray[Any]], npt.NDArray[Any]]
+
+
+class _MultiTaskFeature(_Feature):
+    """Common base class for features shared across multiple tasks.
+
+    Distinguishes a multi-task feature from a single-task one in the
+    ADMM orchestrator: ``_MultiTaskGAM`` calls ``optimize_multi`` with a
+    list of K ``fpumz`` arrays and expects a list of K contributions
+    back. Subclasses also report ``num_tasks``.
+    """
+
+    __type__: str
+    _num_tasks: int
+
+    def __init__(self, name: str, num_tasks: int) -> None:
+        super().__init__(name)
+        if num_tasks < 1:
+            raise ValueError("num_tasks must be >= 1.")
+        self._num_tasks = num_tasks
+
+    @property
+    def num_tasks(self) -> int:
+        return self._num_tasks
+
+    def optimize(self, fpumz: FloatArray, rho: float) -> FloatArray:
+        raise NotImplementedError(
+            "_MultiTaskFeature.optimize is not used; the MultiTaskGAM "
+            "orchestrator calls optimize_multi() with a list of K fpumz "
+            "vectors instead."
+        )
+
+    def initialize(
+        self,
+        x: npt.NDArray[Any],
+        smoothing: float = 1.0,
+        save_flag: bool = False,
+        save_prefix: str | None = None,
+        verbose: bool = False,
+        covariate_class_sizes: npt.NDArray[Any] | None = None,
+    ) -> None:
+        raise NotImplementedError(
+            "_MultiTaskFeature.initialize is not used; the MultiTaskGAM "
+            "orchestrator calls initialize_multi() with a list of K data "
+            "arrays instead."
+        )
+
+    def predict(self, X: npt.NDArray[Any]) -> FloatArray:
+        raise NotImplementedError(
+            "_MultiTaskFeature.predict is not used; the MultiTaskGAM "
+            "orchestrator calls predict_task(k, X) per task."
+        )
+
+    def initialize_multi(
+        self,
+        xs: list[npt.NDArray[Any]],
+        smoothing: float = 1.0,
+        verbose: bool = False,
+    ) -> None:
+        """Compute per-task feature state from K data arrays."""
+        raise NotImplementedError
+
+    def optimize_multi(
+        self,
+        fpumz_list: list[FloatArray],
+        rho: float,
+    ) -> list[FloatArray]:
+        """Solve the per-feature primal step jointly over all K tasks."""
+        raise NotImplementedError
+
+    def predict_task(self, k: int, x: npt.NDArray[Any]) -> FloatArray:
+        """Compute task k's contribution to the linear predictor on new data."""
+        raise NotImplementedError
+
+    def compute_dual_tol_task(self, k: int, y: FloatArray) -> float:
+        """Per-task contribution to the dual-residual tolerance."""
+        raise NotImplementedError
+
+    def num_params_task(self, k: int) -> int:
+        """Per-task parameter count."""
+        raise NotImplementedError
+
+    def dof_task(self, k: int) -> float:
+        """Per-task effective degrees of freedom."""
+        raise NotImplementedError
+
+    # The single-task ABC requires these; persistence is intentionally
+    # not part of the first multi-task slice.
+    def compute_dual_tol(self, y: FloatArray) -> float:
+        raise NotImplementedError
+
+    def num_params(self) -> int:
+        return sum(self.num_params_task(k) for k in range(self._num_tasks))
+
+    def dof(self) -> float:
+        return float(sum(self.dof_task(k) for k in range(self._num_tasks)))
+
+    def _save(self) -> None:
+        raise NotImplementedError(
+            "Persistence is not supported for multi-task features in this slice."
+        )
+
+    def _load(self, filename: str) -> None:
+        raise NotImplementedError(
+            "Persistence is not supported for multi-task features in this slice."
+        )
+
+
+class _MultiTaskLinearFeature(_MultiTaskFeature):
+    """Linear feature shared across K tasks.
+
+    Each task ``k`` gets its own slope ``m_k`` and its own (centered)
+    data column ``x_k = X_k[:, name] - mean(X_k[:, name])``; the
+    contribution to task ``k``'s linear predictor is ``m_k * x_k``.
+
+    Without a coupling regularizer the K subproblems decouple and the
+    primal step reduces to K independent 1-D least-squares solves
+    (matching ``_LinearFeature`` exactly task-by-task).
+
+    Coupling penalties available in this slice:
+
+    ``group_lasso_across_tasks``: ``regularization={"group_lasso_across_tasks":
+    {"coef": λ}}`` adds ``λ * sqrt(sum_k m_k^2 * xtx_k) = λ * ‖[m_1 √xtx_1,
+    ..., m_K √xtx_K]‖_2`` to the joint objective. This is the K-task
+    generalization of the single-task linear group-lasso ``λ * |m| *
+    sqrt(xtx)``: when λ is large enough, the entire K-vector of slopes
+    snaps to zero simultaneously, dropping the feature uniformly across
+    all tasks. Convex (an L2 norm of a linear function of m); composes
+    additively with the per-task quadratic in ``optimize_multi``. With
+    ``λ = 0`` the prox decouples and the feature recovers per-task
+    ordinary-least-squares behavior.
+    """
+
+    def __init__(
+        self,
+        name: str,
+        num_tasks: int,
+        transform: Transform | None = None,
+        regularization: dict[str, Any] | None = None,
+    ) -> None:
+        super().__init__(name, num_tasks)
+        self.__type__ = "multi_task_linear"
+
+        self._has_transform: bool
+        self._transform: Transform
+        if transform is not None:
+            self._has_transform = True
+            self._transform = transform
+        else:
+            self._has_transform = False
+
+        self._has_group_lasso_across_tasks = False
+        self._coef_group_lasso_across_tasks: float = 0.0
+        self._lambda_group_lasso_across_tasks: float = 0.0
+
+        if regularization is not None:
+            unknown = set(regularization) - {"group_lasso_across_tasks"}
+            if unknown:
+                raise ValueError(
+                    f"_MultiTaskLinearFeature: unsupported regularization keys "
+                    f"{sorted(unknown)!r}. The first slice supports only "
+                    "'group_lasso_across_tasks'."
+                )
+            if "group_lasso_across_tasks" in regularization:
+                self._has_group_lasso_across_tasks = True
+                spec = regularization["group_lasso_across_tasks"]
+                if "coef" not in spec:
+                    raise ValueError(
+                        "No coefficient specified for group_lasso_across_tasks."
+                    )
+                self._coef_group_lasso_across_tasks = float(spec["coef"])
+                if self._coef_group_lasso_across_tasks < 0.0:
+                    raise ValueError(
+                        "group_lasso_across_tasks coefficient must be non-negative."
+                    )
+
+        self._xmean: list[float] = []
+        self._x: list[FloatArray] = []
+        self._xtx: list[float] = []
+        self._m: FloatArray = np.zeros(num_tasks)
+        self._b: FloatArray = np.zeros(num_tasks)
+
+    def initialize_multi(
+        self,
+        xs: list[npt.NDArray[Any]],
+        smoothing: float = 1.0,
+        verbose: bool = False,
+    ) -> None:
+        if len(xs) != self._num_tasks:
+            raise ValueError(
+                f"Expected {self._num_tasks} task data arrays, got {len(xs)}."
+            )
+        self._xmean = []
+        self._x = []
+        self._xtx = []
+        for x in xs:
+            if self._has_transform:
+                xx = np.asarray(self._transform(x), dtype=float)
+            else:
+                xx = np.asarray(x, dtype=float)
+            mean = float(np.mean(xx))
+            centered = xx - mean
+            self._xmean.append(mean)
+            self._x.append(centered)
+            self._xtx.append(float(centered.dot(centered)))
+
+        if self._has_group_lasso_across_tasks:
+            self._lambda_group_lasso_across_tasks = (
+                self._coef_group_lasso_across_tasks * smoothing
+            )
+
+        self._m = np.zeros(self._num_tasks)
+        self._b = np.zeros(self._num_tasks)
+        self._verbose = verbose
+
+    def optimize_multi(
+        self,
+        fpumz_list: list[FloatArray],
+        rho: float,
+    ) -> list[FloatArray]:
+        K = self._num_tasks
+        # Per-task unconstrained least-squares optimum.
+        # Per-task subproblem (no coupling):
+        #     argmin_{m_k}  (rho/2) * ||m_k * x_k - fpumz_k||^2  (... + warm-start
+        #     correction matching the single-task linear feature ...)
+        # which yields b_k = x_k . y_k where y_k = m_k * x_k - fpumz_k, then
+        # m_k = b_k / xtx_k. With group_lasso_across_tasks we apply the
+        # K-vector L2 group-lasso prox in the change of variables
+        # eta_k = m_k * sqrt(xtx_k), so the penalty becomes λ ‖eta‖_2 and
+        # the per-task quadratic stays diagonal (xtx_k cancels out). The
+        # closed-form prox is the standard L2 group-lasso shrinkage:
+        #     eta = max(0, 1 - λ / (rho * ‖b_eta‖_2)) * b_eta
+        # where b_eta = (sqrt(xtx_k) * m_k_unpen)_k.
+        b = np.empty(K)
+        for k in range(K):
+            xk = self._x[k]
+            mk = self._m[k]
+            yk = mk * xk - fpumz_list[k]
+            b[k] = float(xk.dot(yk))
+
+        m_unpen = np.empty(K)
+        for k in range(K):
+            xtx_k = self._xtx[k]
+            m_unpen[k] = b[k] / xtx_k if xtx_k > 0.0 else 0.0
+
+        if (
+            self._has_group_lasso_across_tasks
+            and self._lambda_group_lasso_across_tasks > 0.0
+        ):
+            sqrt_xtx = np.sqrt(np.asarray(self._xtx, dtype=float))
+            eta = m_unpen * sqrt_xtx
+            eta_norm = float(np.linalg.norm(eta))
+            threshold = self._lambda_group_lasso_across_tasks / rho
+            if eta_norm <= threshold:
+                self._m = np.zeros(K)
+            else:
+                shrink = 1.0 - threshold / eta_norm
+                eta_new = shrink * eta
+                m_new = np.zeros(K)
+                for k in range(K):
+                    if sqrt_xtx[k] > 0.0:
+                        m_new[k] = eta_new[k] / sqrt_xtx[k]
+                self._m = m_new
+        else:
+            self._m = m_unpen
+
+        for k in range(K):
+            self._b[k] = -self._m[k] * self._xmean[k]
+
+        return [self._m[k] * self._x[k] for k in range(K)]
+
+    def predict_task(self, k: int, x: npt.NDArray[Any]) -> FloatArray:
+        if self._has_transform:
+            xx = np.asarray(self._transform(x), dtype=float)
+        else:
+            xx = np.asarray(x, dtype=float)
+        return np.asarray(self._m[k] * xx + self._b[k], dtype=float)
+
+    def compute_dual_tol_task(self, k: int, y: FloatArray) -> float:
+        # Mirrors _LinearFeature.compute_dual_tol per task.
+        ybar = float(np.sum(y))
+        xty = float(self._x[k].dot(y))
+        xmean = self._xmean[k]
+        return (xty + 2 * xmean * ybar) * xty + (1.0 + xmean * xmean) * ybar * ybar
+
+    def num_params_task(self, k: int) -> int:
+        return 1
+
+    def dof_task(self, k: int) -> float:
+        # Group-lasso-across-tasks zeros the entire K-vector at once, so
+        # when the feature has been driven to zero, no task contributes a
+        # degree of freedom. Otherwise, one slope per task.
+        if self._has_group_lasso_across_tasks and math.isclose(
+            float(self._m[k]), 0.0, abs_tol=1e-12
+        ):
+            return 0.0
+        return 1.0
+
+    def __str__(self) -> str:
+        slopes = ", ".join(f"{m:.06g}" for m in self._m)
+        return f"MultiTaskFeature {self._name}: betas = [{slopes}]\n"

--- a/gamdist/multi_task_gamdist.py
+++ b/gamdist/multi_task_gamdist.py
@@ -1,0 +1,690 @@
+# Copyright 2017 Match Group, LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you
+# may not use this file except in compliance with the License. You may
+# obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied.  See the License for the specific language governing
+# permissions and limitations under the License.
+#
+# Passing untrusted user input may have unintended consequences. Not
+# designed to consume input from unknown sources (i.e., the public
+# internet).
+#
+# This file has been modified from the original release by Match Group
+# LLC. A description of changes may be found in the change log
+# accompanying this source code.
+
+"""Multi-task GAM: K supervised-learning tasks fit jointly under a
+shared feature set with optional convex coupling regularization.
+
+Per the design discussion on issue #39 (and CLAUDE.md's seam principle):
+
+  - Per-task primal step is unchanged: each task's task-local features
+    run their existing `optimize(fpumz_k, rho)` independently. A
+    multi-task feature wraps K of those into a single
+    `optimize_multi(fpumz_list, rho)` call, which is the only place the
+    cross-task coupling penalty enters.
+  - Per-task proximal step is unchanged: K independent prox calls,
+    each with its own `(family_k, link_k, y_k)` -- so tasks can use
+    different family/link pairs.
+  - `MultiTaskGAM` is a separate class whose state (`f_bar`,
+    `z_bar`, `u`, residual histories, offset, ...) is a length-K list.
+    Single-task `GAM` is unchanged.
+
+The first concrete coupling penalty is group-lasso-across-tasks on
+linear features (see `_MultiTaskLinearFeature`); persistence,
+`summary()`, plotting, model-selection statistics, and per-task
+`tasks=` routing are out of scope for this slice.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import Any, Literal
+
+import numpy as np
+import numpy.typing as npt
+import pandas as pd
+import scipy.linalg as linalg
+import scipy.special as special
+import scipy.stats as stats
+
+from . import proximal_operators as po
+from .gamdist import (
+    CANONICAL_LINKS,
+    FAMILIES,
+    FAMILIES_WITH_KNOWN_DISPERSIONS,
+    LINKS,
+    QUASI_BASE_FAMILY,
+    SUPPORTED_FAMILY_LINK_PAIRS,
+    Family,
+    Link,
+)
+from .multi_task_features import _MultiTaskFeature, _MultiTaskLinearFeature
+
+FloatArray = npt.NDArray[np.float64]
+MultiTaskFeatureType = Literal["linear"]
+
+
+def _link_callables(
+    link: str,
+) -> tuple[Callable[[FloatArray], FloatArray], Callable[[FloatArray], FloatArray]]:
+    """Return ``(link, inv_link)`` callables for a link name.
+
+    Mirrors the inline link/inv_link lambdas in ``GAM.__init__``;
+    factored out so a list of K of them can be built without copy-paste.
+    """
+    if link == "identity":
+        return (lambda x: x, lambda x: x)
+    if link == "logistic":
+        return (
+            lambda x: np.asarray(special.logit(x), dtype=float),
+            lambda x: np.asarray(special.expit(x), dtype=float),
+        )
+    if link == "probit":
+        return (
+            lambda x: np.asarray(stats.norm.ppf(x), dtype=float),
+            lambda x: np.asarray(stats.norm.cdf(x), dtype=float),
+        )
+    if link == "complementary_log_log":
+        return (
+            lambda x: np.asarray(np.log(-np.log(1.0 - x)), dtype=float),
+            lambda x: np.asarray(1.0 - np.exp(-np.exp(x)), dtype=float),
+        )
+    if link == "log":
+        return (
+            lambda x: np.asarray(np.log(x), dtype=float),
+            lambda x: np.asarray(np.exp(x), dtype=float),
+        )
+    if link == "reciprocal":
+        return (lambda x: 1.0 / x, lambda x: 1.0 / x)
+    if link == "reciprocal_squared":
+        return (
+            lambda x: np.asarray(1.0 / (x * x), dtype=float),
+            lambda x: np.asarray(1.0 / np.sqrt(x), dtype=float),
+        )
+    raise ValueError(f"{link!r} link not supported")
+
+
+class MultiTaskGAM:
+    """Generalized Additive Model fit jointly across K tasks.
+
+    Each task ``k`` has its own ``(family_k, link_k)`` pair, its own
+    response ``y_k`` (lengths may differ across tasks), and its own
+    feature data; coefficients are tied together by the coupling
+    regularizer attached to each multi-task feature.
+
+    Parameters
+    ----------
+    families : list[str]
+        Length-K list of family names. Each entry must be one of the
+        single-task families supported by ``GAM``. Tasks may use
+        different families.
+    links : list[str | None] or None
+        Length-K list of link names; defaults to the canonical link of
+        each family. ``None`` entries fall back to the canonical link.
+    dispersions : list[float | None] or None
+        Optional per-task fixed dispersion. ``None`` entries follow
+        the single-task ``GAM`` defaults (e.g. binomial / poisson are
+        fixed at 1).
+    name : str or None
+        Optional model name. Persistence is not supported in this
+        slice; the name is currently informational only.
+
+    Notes
+    -----
+    Several features of single-task ``GAM`` are intentionally not yet
+    wired up for the multi-task case in this slice and raise
+    ``NotImplementedError`` if invoked: ``save_flag``,
+    ``load_from_file``, ``summary``, ``plot``, ``aic`` / ``aicc`` /
+    ``gcv`` / ``ubre``, ``confidence_intervals``, robust covariance,
+    ``quantile`` / ``huber`` families, covariate classes, and the
+    ``estimate_overdispersion`` path.
+    """
+
+    def __init__(
+        self,
+        families: list[Family],
+        links: list[Link | None] | None = None,
+        dispersions: list[float | None] | None = None,
+        name: str | None = None,
+    ) -> None:
+        if not isinstance(families, list) or len(families) < 1:
+            raise ValueError("families must be a non-empty list.")
+        K = len(families)
+        for f in families:
+            if f not in FAMILIES:
+                raise ValueError(f"{f!r} family not supported")
+            if f in {"quantile", "huber"}:
+                raise NotImplementedError(
+                    f"family {f!r} is not yet supported in MultiTaskGAM "
+                    "(needs per-task tau / delta plumbing)."
+                )
+
+        if links is None:
+            links_resolved: list[str] = [str(CANONICAL_LINKS[fam]) for fam in families]
+        else:
+            if len(links) != K:
+                raise ValueError(
+                    f"links has length {len(links)} but families has length {K}."
+                )
+            links_resolved = []
+            for k, lk in enumerate(links):
+                if lk is None:
+                    links_resolved.append(str(CANONICAL_LINKS[families[k]]))
+                elif lk in LINKS:
+                    links_resolved.append(lk)
+                else:
+                    raise ValueError(f"{lk!r} link not supported")
+
+        for k in range(K):
+            pair = (families[k], links_resolved[k])
+            if pair not in SUPPORTED_FAMILY_LINK_PAIRS:
+                canonical = CANONICAL_LINKS[families[k]]
+                raise ValueError(
+                    f"task {k}: ({families[k]!r}, {links_resolved[k]!r}) is "
+                    "not a supported (family, link) combination. Per the "
+                    "convexity-only design (see CLAUDE.md), only pairs with "
+                    "a dedicated convex proximal-operator implementation are "
+                    f"accepted; use link={canonical!r} for "
+                    f"family={families[k]!r}."
+                )
+
+        if dispersions is None:
+            dispersions_resolved: list[float | None] = [None] * K
+        elif len(dispersions) != K:
+            raise ValueError(
+                f"dispersions has length {len(dispersions)} but families has "
+                f"length {K}."
+            )
+        else:
+            dispersions_resolved = list(dispersions)
+
+        self._num_tasks = K
+        self._families: list[Family] = list(families)
+        self._links: list[str] = list(links_resolved)
+        self._base_families: list[str] = [
+            QUASI_BASE_FAMILY.get(f, f) for f in self._families
+        ]
+        self._known_dispersion: list[bool] = []
+        self._dispersion: list[float] = []
+        for k in range(K):
+            d = dispersions_resolved[k]
+            if d is not None:
+                self._known_dispersion.append(True)
+                self._dispersion.append(float(d))
+            elif self._families[k] in FAMILIES_WITH_KNOWN_DISPERSIONS:
+                self._known_dispersion.append(True)
+                self._dispersion.append(
+                    float(FAMILIES_WITH_KNOWN_DISPERSIONS[self._families[k]])
+                )
+            else:
+                self._known_dispersion.append(False)
+                self._dispersion.append(1.0)
+
+        self._eval_link: list[Callable[[FloatArray], FloatArray]] = []
+        self._eval_inv_link: list[Callable[[FloatArray], FloatArray]] = []
+        for k in range(K):
+            link_k, inv_k = _link_callables(self._links[k])
+            self._eval_link.append(link_k)
+            self._eval_inv_link.append(inv_k)
+
+        self._features: dict[str, _MultiTaskFeature] = {}
+        self._num_features = 0
+        self._fitted = False
+        self._name = name
+        # Placeholders so any inherited code that references these
+        # single-task attributes does not blow up.
+        self._tau = None
+        self._delta = None
+
+    def add_feature(
+        self,
+        name: str,
+        type: MultiTaskFeatureType,
+        transform: Callable[[npt.NDArray[Any]], npt.NDArray[Any]] | None = None,
+        regularization: dict[str, Any] | None = None,
+    ) -> None:
+        """Add a feature shared across all K tasks.
+
+        The first slice supports only ``type='linear'``. Each task
+        ``k`` contributes ``m_k * (x_k - mean(x_k))`` to its own
+        linear predictor; the K slopes ``m_1, ..., m_K`` may be
+        coupled by a convex coupling regularizer (see
+        ``_MultiTaskLinearFeature`` for the supported penalties).
+        """
+        feat: _MultiTaskFeature
+        if type == "linear":
+            feat = _MultiTaskLinearFeature(
+                name,
+                num_tasks=self._num_tasks,
+                transform=transform,
+                regularization=regularization,
+            )
+        else:
+            raise ValueError(
+                f"MultiTaskGAM features of type {type!r} not supported in "
+                "this slice (only 'linear' is wired up; categorical / "
+                "spline can be added by analogy)."
+            )
+        self._features[name] = feat
+        self._num_features += 1
+
+    def fit(
+        self,
+        Xs: list[pd.DataFrame],
+        ys: list[npt.NDArray[Any]],
+        weights: list[npt.NDArray[Any] | None] | None = None,
+        smoothing: float = 1.0,
+        verbose: bool = False,
+        max_its: int = 100,
+    ) -> None:
+        """Fit the multi-task GAM via K-coupled ADMM.
+
+        Parameters
+        ----------
+        Xs : list[pandas.DataFrame]
+            Length-K list of per-task design matrices. Column names
+            must include every feature added via ``add_feature``.
+            Per-task row counts may differ.
+        ys : list[ndarray]
+            Length-K list of per-task response arrays. ``len(ys[k])``
+            must equal ``len(Xs[k])``.
+        weights : list[ndarray | None] or None
+            Optional per-task observation weights. ``None`` (or a
+            ``None`` entry) means unit weights for that task.
+        smoothing : float
+            Multiplicative scale applied to every feature's
+            regularization coefficient (matches single-task ``GAM``).
+        verbose : bool
+            Print per-iteration progress.
+        max_its : int
+            Maximum ADMM iterations (per the joint stopping rule).
+        """
+        K = self._num_tasks
+        if not isinstance(Xs, list) or len(Xs) != K:
+            raise ValueError(f"Xs must be a list of length {K}.")
+        if not isinstance(ys, list) or len(ys) != K:
+            raise ValueError(f"ys must be a list of length {K}.")
+        if weights is None:
+            weights_list: list[npt.NDArray[Any] | None] = [None] * K
+        else:
+            if len(weights) != K:
+                raise ValueError(f"weights must be a list of length {K}.")
+            weights_list = list(weights)
+
+        for k in range(K):
+            if len(Xs[k]) != len(ys[k]):
+                raise ValueError(
+                    f"task {k}: Xs has {len(Xs[k])} rows, ys has {len(ys[k])}."
+                )
+            wk = weights_list[k]
+            if wk is not None and len(wk) != len(ys[k]):
+                raise ValueError(
+                    f"task {k}: weights has length {len(wk)} but "
+                    f"ys has length {len(ys[k])}."
+                )
+
+        self._rho = 0.1
+        eps_abs = 1e-3
+        eps_rel = 1e-3
+
+        self._num_obs: list[int] = [len(ys[k]) for k in range(K)]
+        self._y: list[FloatArray] = [np.asarray(ys[k]).flatten() for k in range(K)]
+        self._weights: list[npt.NDArray[Any] | None] = weights_list
+        self._offset: list[float] = []
+        for k in range(K):
+            yk = self._y[k]
+            mean_arr = np.asarray(np.mean(yk), dtype=float).reshape(())
+            self._offset.append(float(self._eval_link[k](mean_arr)))
+
+        # Initialize features. Each multi-task feature builds K
+        # parallel per-task data caches in one call.
+        for name, feature in self._features.items():
+            xs = [np.asarray(Xs[k][name].values) for k in range(K)]
+            feature.initialize_multi(xs, smoothing=smoothing, verbose=verbose)
+
+        N = self._num_features
+
+        # Per-task ADMM state. Each is a list of K arrays (potentially
+        # of different lengths).
+        self.f_bar: list[FloatArray] = [
+            np.full((self._num_obs[k],), self._offset[k] / N if N > 0 else 0.0)
+            for k in range(K)
+        ]
+        self.z_bar: list[FloatArray] = [np.zeros(self._num_obs[k]) for k in range(K)]
+        self.u: list[FloatArray] = [np.zeros(self._num_obs[k]) for k in range(K)]
+        self.prim_res: list[float] = []
+        self.dual_res: list[float] = []
+        self.prim_tol: list[float] = []
+        self.dual_tol: list[float] = []
+        self.dev: list[list[float]] = []
+
+        if N == 0:
+            # Degenerate: no features. Fit reduces to per-task offsets.
+            self._fitted = True
+            return
+
+        fj: dict[str, list[FloatArray]] = {
+            name: [np.zeros(self._num_obs[k]) for k in range(K)]
+            for name in self._features
+        }
+        self._admm_loop_multi(max_its, eps_abs, eps_rel, fj, verbose)
+        self._fitted = True
+
+    def _admm_loop_multi(
+        self,
+        max_its: int,
+        eps_abs: float,
+        eps_rel: float,
+        fj: dict[str, list[FloatArray]],
+        verbose: bool,
+    ) -> None:
+        """Run the K-coupled ADMM iterations.
+
+        Mirrors ``GAM._admm_loop`` but holds per-task lists for every
+        ADMM-state vector. The per-feature primal step is one call per
+        feature (which internally handles all K tasks); the per-task
+        proximal step is K independent calls.
+        """
+        K = self._num_tasks
+        N = self._num_features
+
+        for i in range(max_its):
+            if verbose:
+                print(f"Iteration {i:d}")
+                print("Optimizing primal variables")
+
+            fpumz = [N * (self.f_bar[k] + self.u[k] - self.z_bar[k]) for k in range(K)]
+            fj_new: dict[str, list[FloatArray]] = {}
+            f_new: list[FloatArray] = [
+                np.full((self._num_obs[k],), self._offset[k]) for k in range(K)
+            ]
+            for name, feature in self._features.items():
+                contribs = feature.optimize_multi(fpumz, self._rho)
+                fj_new[name] = contribs
+                for k in range(K):
+                    f_new[k] = f_new[k] + contribs[k]
+
+            for k in range(K):
+                f_new[k] = f_new[k] / N
+
+            if verbose:
+                print("Optimizing dual variables")
+
+            z_new: list[FloatArray] = [
+                self._optimize_task(k, self.u[k] + f_new[k], N) for k in range(K)
+            ]
+
+            for k in range(K):
+                self.u[k] = self.u[k] + (f_new[k] - z_new[k])
+
+            # Per-task primal / dual residuals; we declare convergence
+            # only when *every* task is below its tolerance. This is
+            # the strongest natural rule and falls out of the existing
+            # single-task formulae applied per task.
+            prim_res_per_task = np.zeros(K)
+            dual_res_per_task = np.zeros(K)
+            prim_tol_per_task = np.zeros(K)
+            dual_tol_per_task = np.zeros(K)
+
+            for k in range(K):
+                prim_res_per_task[k] = np.sqrt(N) * linalg.norm(f_new[k] - z_new[k])
+
+                dual_sq = 0.0
+                norm_ax_sq = 0.0
+                norm_bz_sq = 0.0
+                norm_aty_sq = 0.0
+                num_params_k = 0
+                for name, feature in self._features.items():
+                    dr = (
+                        (fj_new[name][k] - fj[name][k])
+                        + (z_new[k] - self.z_bar[k])
+                        - (f_new[k] - self.f_bar[k])
+                    )
+                    dual_sq += float(dr.dot(dr))
+                    norm_ax_sq += float(fj_new[name][k].dot(fj_new[name][k]))
+                    zik = fj_new[name][k] + z_new[k] - f_new[k]
+                    norm_bz_sq += float(zik.dot(zik))
+                    norm_aty_sq += feature.compute_dual_tol_task(k, self.u[k])
+                    num_params_k += feature.num_params_task(k)
+
+                dual_res_per_task[k] = self._rho * np.sqrt(dual_sq)
+                norm_ax = np.sqrt(norm_ax_sq)
+                norm_bz = np.sqrt(norm_bz_sq)
+                norm_aty = np.sqrt(norm_aty_sq)
+                prim_tol_per_task[k] = np.sqrt(
+                    self._num_obs[k] * N
+                ) * eps_abs + eps_rel * max(norm_ax, norm_bz)
+                dual_tol_per_task[k] = (
+                    np.sqrt(num_params_k) * eps_abs + eps_rel * norm_aty
+                )
+
+            self.f_bar = f_new
+            self.z_bar = z_new
+            fj = fj_new
+
+            # Aggregate per-task residuals/tolerances by max for the
+            # joint convergence trace; the per-task arrays are
+            # available via ``residuals_per_task`` if a caller wants
+            # to inspect them.
+            self.prim_res.append(float(np.max(prim_res_per_task)))
+            self.dual_res.append(float(np.max(dual_res_per_task)))
+            self.prim_tol.append(float(np.max(prim_tol_per_task)))
+            self.dual_tol.append(float(np.max(dual_tol_per_task)))
+            self.dev.append(self.deviance())
+
+            converged = bool(
+                np.all(prim_res_per_task < prim_tol_per_task)
+                and np.all(dual_res_per_task < dual_tol_per_task)
+            )
+            if converged:
+                if verbose:
+                    print("Fit converged")
+                break
+        else:
+            if verbose:
+                print("Fit did not converge")
+
+    def _optimize_task(self, k: int, upf: FloatArray, N: int) -> FloatArray:
+        """Per-task proximal step. Mirrors ``GAM._optimize`` but
+        parameterized by task index ``k`` so each task uses its own
+        ``(family, link, y, weights)``.
+        """
+        base = self._base_families[k]
+        rho = self._rho
+        y = self._y[k]
+        w = self._weights[k]
+        inv = self._eval_inv_link[k]
+
+        prox: Any
+        if base == "normal":
+            prox = po._prox_normal_identity
+        elif base == "binomial":
+            prox = po._prox_binomial_logit
+            return (1.0 / N) * prox(N * upf, rho, y, None, w, inv)
+        elif base == "poisson":
+            prox = po._prox_poisson_log
+        elif base == "gamma":
+            prox = po._prox_gamma_reciprocal
+        elif base == "inverse_gaussian":
+            prox = po._prox_inv_gaussian_reciprocal_squared
+        else:
+            raise ValueError(
+                f"task {k}: family {self._families[k]!r} with link "
+                f"{self._links[k]!r} not supported in MultiTaskGAM."
+            )
+
+        return (1.0 / N) * prox(N * upf, rho, y, w=w, inv_link=inv)
+
+    def predict(
+        self,
+        X: pd.DataFrame | list[pd.DataFrame],
+    ) -> list[FloatArray]:
+        """Predict per-task mean responses.
+
+        Parameters
+        ----------
+        X : pandas.DataFrame or list[pandas.DataFrame]
+            If a single DataFrame is passed, the same predictor matrix
+            is used for every task and the K predictions all have the
+            same length. If a list of K DataFrames is passed, each
+            task's prediction uses its own DataFrame.
+
+        Returns
+        -------
+        mus : list of arrays
+            Length-K list of predicted mean responses; ``mus[k]`` has
+            shape ``(len(X[k]),)``.
+        """
+        if not self._fitted:
+            raise AttributeError("Model not yet fit.")
+
+        K = self._num_tasks
+        if isinstance(X, pd.DataFrame):
+            Xs = [X for _ in range(K)]
+        else:
+            if len(X) != K:
+                raise ValueError(
+                    f"X must be a DataFrame or a list of length {K}; got {len(X)}."
+                )
+            Xs = list(X)
+
+        mus: list[FloatArray] = []
+        for k in range(K):
+            num_points = len(Xs[k])
+            eta = np.full((num_points,), self._offset[k])
+            for name, feature in self._features.items():
+                eta = eta + feature.predict_task(k, np.asarray(Xs[k][name].values))
+            mus.append(np.asarray(self._eval_inv_link[k](eta), dtype=float))
+        return mus
+
+    def deviance(
+        self,
+        X: list[pd.DataFrame] | None = None,
+        y: list[npt.NDArray[Any]] | None = None,
+        weights: list[npt.NDArray[Any] | None] | None = None,
+    ) -> list[float]:
+        """Per-task deviance.
+
+        With no arguments, returns the training deviance of each task
+        evaluated against the current ADMM iterate. Otherwise, the
+        deviance is computed against the supplied per-task data.
+        """
+        K = self._num_tasks
+        if X is None or y is None:
+            ys = self._y
+            mus: list[FloatArray] = [
+                np.asarray(
+                    self._eval_inv_link[k](self._num_features * self.f_bar[k]),
+                    dtype=float,
+                )
+                for k in range(K)
+            ]
+            ws = self._weights
+        else:
+            if len(X) != K or len(y) != K:
+                raise ValueError(f"X and y must each be lists of length {K}.")
+            ys = [np.asarray(y[k]).flatten() for k in range(K)]
+            mus = self.predict(list(X))
+            if weights is None:
+                ws = [None] * K
+            else:
+                if len(weights) != K:
+                    raise ValueError(f"weights must be a list of length {K}.")
+                ws = list(weights)
+
+        return [self._deviance_task(k, ys[k], mus[k], w=ws[k]) for k in range(K)]
+
+    def _deviance_task(
+        self,
+        k: int,
+        y: FloatArray,
+        mu: FloatArray,
+        w: npt.NDArray[Any] | None = None,
+    ) -> float:
+        """Per-task deviance, dispatching on this task's family.
+
+        Mirrors ``GAM._deviance_from_mu`` but parameterized by task
+        index. Covariate-class data is not yet supported in
+        ``MultiTaskGAM``, so ``m`` is always 1.
+        """
+        base = self._base_families[k]
+        if base == "normal":
+            r = y - mu
+            if w is None:
+                return float(r.dot(r))
+            return float(w.dot(r * r))
+        if base == "binomial":
+            eps = np.finfo(float).eps
+            mu_c = np.clip(mu, eps, 1.0 - eps)
+            term = y * np.log(mu_c) + (1.0 - y) * np.log1p(-mu_c)
+            if w is None:
+                return float(-2.0 * np.sum(term))
+            return float(-2.0 * w.dot(term))
+        if base == "poisson":
+            y_log_term = np.where(y > 0, y * np.log(np.where(y > 0, y, 1.0) / mu), 0.0)
+            term = y_log_term - (y - mu)
+            if w is None:
+                return float(2.0 * np.sum(term))
+            return float(2.0 * w.dot(term))
+        if base == "gamma":
+            tiny = np.finfo(float).tiny
+            y_safe = np.where(y > 0, y, tiny)
+            mu_safe = np.where(mu > 0, mu, tiny)
+            term = -np.log(y_safe / mu_safe) + (y - mu_safe) / mu_safe
+            if w is None:
+                return float(2.0 * np.sum(term))
+            return float(2.0 * w.dot(term))
+        if base == "inverse_gaussian":
+            r = y - mu
+            term = r * r / (mu * mu * y)
+            if w is None:
+                return float(np.sum(term))
+            return float(w.dot(term))
+        raise ValueError(
+            f"task {k}: deviance not implemented for family {self._families[k]!r}."
+        )
+
+    # --- single-task GAM features intentionally NOT wired up in this
+    # slice; raise so callers find out at call time rather than
+    # silently getting nonsense. ---
+
+    def summary(self) -> None:
+        raise NotImplementedError("summary() is not yet implemented for MultiTaskGAM.")
+
+    def plot(self, name: str, true_fn: Any = None) -> None:
+        raise NotImplementedError("plot() is not yet implemented for MultiTaskGAM.")
+
+    def confidence_intervals(self, *args: Any, **kwargs: Any) -> Any:
+        raise NotImplementedError(
+            "confidence_intervals() is not yet implemented for MultiTaskGAM."
+        )
+
+    def aic(self) -> float:
+        raise NotImplementedError("aic() is not yet implemented for MultiTaskGAM.")
+
+    def aicc(self) -> float:
+        raise NotImplementedError("aicc() is not yet implemented for MultiTaskGAM.")
+
+    def gcv(self, gamma: float = 1.0) -> float:
+        raise NotImplementedError("gcv() is not yet implemented for MultiTaskGAM.")
+
+    def ubre(self, gamma: float = 1.0) -> float:
+        raise NotImplementedError("ubre() is not yet implemented for MultiTaskGAM.")
+
+    def _save(self) -> None:
+        raise NotImplementedError(
+            "Persistence is not yet implemented for MultiTaskGAM."
+        )
+
+    def _load(self, filename: str) -> None:
+        raise NotImplementedError(
+            "Persistence is not yet implemented for MultiTaskGAM."
+        )

--- a/tests/test_multi_task_gam.py
+++ b/tests/test_multi_task_gam.py
@@ -1,0 +1,379 @@
+"""Tests for ``MultiTaskGAM`` and ``_MultiTaskLinearFeature``.
+
+The first multi-task slice (issue #39) covers:
+
+- Per-task ``(family, link)`` heterogeneity (normal+identity and
+  binomial+logit verified together).
+- One coupling penalty: group-lasso across tasks on a linear feature,
+  which zeros the feature simultaneously across all tasks once λ is
+  large enough.
+- Different ``n_k`` per task (the multi-task ADMM holds per-task
+  primal/dual state, so unequal lengths fall out for free).
+
+Persistence, summary/plot/CI/AIC paths are intentionally
+``NotImplementedError`` in this slice; those are exercised below to
+guard against accidental wiring-up without tests.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+import pytest
+import scipy.special as special
+
+from gamdist import GAM, MultiTaskGAM
+from gamdist.multi_task_features import _MultiTaskLinearFeature
+
+# --- _MultiTaskLinearFeature unit tests ---
+
+
+def test_feature_rejects_zero_tasks() -> None:
+    with pytest.raises(ValueError, match="num_tasks must be >= 1"):
+        _MultiTaskLinearFeature("x", num_tasks=0)
+
+
+def test_feature_rejects_unknown_regularization() -> None:
+    with pytest.raises(ValueError, match="unsupported regularization"):
+        _MultiTaskLinearFeature("x", num_tasks=2, regularization={"l1": {"coef": 0.1}})
+
+
+def test_feature_requires_coef_for_group_lasso() -> None:
+    with pytest.raises(ValueError, match="No coefficient specified"):
+        _MultiTaskLinearFeature(
+            "x", num_tasks=2, regularization={"group_lasso_across_tasks": {}}
+        )
+
+
+def test_feature_rejects_negative_coef() -> None:
+    with pytest.raises(ValueError, match="must be non-negative"):
+        _MultiTaskLinearFeature(
+            "x",
+            num_tasks=2,
+            regularization={"group_lasso_across_tasks": {"coef": -0.1}},
+        )
+
+
+def test_feature_smoothing_scales_lambda() -> None:
+    feat = _MultiTaskLinearFeature(
+        "x",
+        num_tasks=2,
+        regularization={"group_lasso_across_tasks": {"coef": 0.4}},
+    )
+    feat.initialize_multi(
+        [np.array([0.0, 1.0, 2.0, 3.0]), np.array([0.0, 1.0, 2.0, 3.0])],
+        smoothing=2.5,
+    )
+    assert feat._has_group_lasso_across_tasks
+    assert feat._lambda_group_lasso_across_tasks == pytest.approx(1.0)
+
+
+def test_feature_huge_lambda_zeros_all_slopes() -> None:
+    rng = np.random.default_rng(0)
+    n = 100
+    x1 = rng.normal(size=n)
+    x2 = rng.normal(size=n)
+    fpumz1 = rng.normal(size=n)
+    fpumz2 = rng.normal(size=n)
+
+    feat = _MultiTaskLinearFeature(
+        "x",
+        num_tasks=2,
+        regularization={"group_lasso_across_tasks": {"coef": 1e6}},
+    )
+    feat.initialize_multi([x1, x2])
+    feat.optimize_multi([fpumz1, fpumz2], rho=1.0)
+    assert np.all(feat._m == 0.0)
+
+
+def test_feature_lambda_zero_decouples_tasks() -> None:
+    """With λ=0, each task's slope should match running the K subproblems
+    independently as ordinary least-squares.
+    """
+    rng = np.random.default_rng(1)
+    n1, n2 = 80, 120
+    x1 = rng.normal(size=n1)
+    x2 = rng.normal(size=n2)
+    fpumz1 = rng.normal(size=n1)
+    fpumz2 = rng.normal(size=n2)
+
+    feat = _MultiTaskLinearFeature(
+        "x",
+        num_tasks=2,
+        regularization={"group_lasso_across_tasks": {"coef": 0.0}},
+    )
+    feat.initialize_multi([x1, x2])
+    feat.optimize_multi([fpumz1, fpumz2], rho=1.0)
+
+    # Closed form for each task in isolation: m_k = -(x_k . fpumz_k) / (x_k . x_k)
+    # because the warm-start uses self._m=0 so y = -fpumz.
+    for k, (x, fpumz) in enumerate([(x1, fpumz1), (x2, fpumz2)]):
+        x_c = x - x.mean()
+        b = float(x_c.dot(-fpumz))
+        expected = b / float(x_c.dot(x_c))
+        assert feat._m[k] == pytest.approx(expected, rel=1e-10, abs=1e-10)
+
+
+# --- MultiTaskGAM construction tests ---
+
+
+def test_construction_rejects_empty_families() -> None:
+    with pytest.raises(ValueError, match="non-empty list"):
+        MultiTaskGAM(families=[])  # type: ignore[arg-type]
+
+
+def test_construction_rejects_unknown_family() -> None:
+    with pytest.raises(ValueError, match="not supported"):
+        MultiTaskGAM(families=["bogus"])  # type: ignore[list-item]
+
+
+def test_construction_rejects_quantile_family() -> None:
+    with pytest.raises(NotImplementedError, match="quantile"):
+        MultiTaskGAM(families=["normal", "quantile"])
+
+
+def test_construction_rejects_mismatched_links_length() -> None:
+    with pytest.raises(ValueError, match="length"):
+        MultiTaskGAM(families=["normal", "normal"], links=["identity"])
+
+
+def test_construction_rejects_unsupported_pair() -> None:
+    with pytest.raises(ValueError, match="not a supported"):
+        # binomial + identity is not in SUPPORTED_FAMILY_LINK_PAIRS
+        MultiTaskGAM(families=["binomial"], links=["identity"])
+
+
+def test_construction_defaults_to_canonical_links() -> None:
+    mt = MultiTaskGAM(families=["normal", "binomial", "poisson"])
+    assert mt._links == ["identity", "logistic", "log"]
+    assert mt._known_dispersion == [False, True, True]
+
+
+def test_construction_per_task_dispersions() -> None:
+    mt = MultiTaskGAM(families=["normal", "normal"], dispersions=[1.0, None])
+    assert mt._known_dispersion == [True, False]
+    assert mt._dispersion[0] == 1.0
+
+
+# --- MultiTaskGAM end-to-end fit tests ---
+
+
+def _gen_two_task_normal(
+    n1: int = 250, n2: int = 350, seed: int = 0
+) -> tuple[list[pd.DataFrame], list[np.ndarray], dict[str, tuple[float, float]]]:
+    """Generate two normal+identity tasks with different lengths.
+
+    Returns the design matrices, responses, and the true per-feature
+    per-task slopes so tests can assert recovery.
+    """
+    rng = np.random.default_rng(seed)
+    truth = {"a": (1.5, 0.8), "b": (-0.7, 0.3)}
+    a1 = rng.normal(size=n1)
+    b1 = rng.normal(size=n1)
+    a2 = rng.normal(size=n2)
+    b2 = rng.normal(size=n2)
+    y1 = truth["a"][0] * a1 + truth["b"][0] * b1 + 0.05 * rng.normal(size=n1)
+    y2 = truth["a"][1] * a2 + truth["b"][1] * b2 + 0.05 * rng.normal(size=n2)
+    return (
+        [pd.DataFrame({"a": a1, "b": b1}), pd.DataFrame({"a": a2, "b": b2})],
+        [y1, y2],
+        truth,
+    )
+
+
+def test_fit_unequal_task_lengths_recovers_truth() -> None:
+    Xs, ys, truth = _gen_two_task_normal()
+    mt = MultiTaskGAM(families=["normal", "normal"])
+    mt.add_feature("a", type="linear")
+    mt.add_feature("b", type="linear")
+    mt.fit(Xs, ys, max_its=80)
+
+    assert mt._fitted
+    # n_k differs: convergence trace should still be a single sequence
+    # (max-across-tasks rule), with the final iterate below tolerance.
+    assert mt.prim_res[-1] < mt.prim_tol[-1]
+    assert mt.dual_res[-1] < mt.dual_tol[-1]
+
+    a = mt._features["a"]
+    b = mt._features["b"]
+    assert a._m[0] == pytest.approx(truth["a"][0], abs=0.05)
+    assert a._m[1] == pytest.approx(truth["a"][1], abs=0.05)
+    assert b._m[0] == pytest.approx(truth["b"][0], abs=0.05)
+    assert b._m[1] == pytest.approx(truth["b"][1], abs=0.05)
+
+
+def test_fit_no_coupling_matches_independent_gams() -> None:
+    """λ=0 (or no coupling) should give per-task slopes within ADMM
+    tolerance of two separately-fit single-task GAMs.
+    """
+    Xs, ys, _ = _gen_two_task_normal(seed=4)
+
+    # Independent baseline
+    independents = []
+    for X, y in zip(Xs, ys, strict=True):
+        m = GAM(family="normal")
+        m.add_feature("a", type="linear")
+        m.add_feature("b", type="linear")
+        m.fit(X, y, max_its=200)
+        independents.append(m)
+
+    mt = MultiTaskGAM(families=["normal", "normal"])
+    mt.add_feature("a", type="linear")
+    mt.add_feature("b", type="linear")
+    mt.fit(Xs, ys, max_its=200)
+
+    for k, ind in enumerate(independents):
+        assert mt._features["a"]._m[k] == pytest.approx(
+            ind._features["a"]._m,
+            abs=2e-2,  # type: ignore[attr-defined]
+        )
+        assert mt._features["b"]._m[k] == pytest.approx(
+            ind._features["b"]._m,
+            abs=2e-2,  # type: ignore[attr-defined]
+        )
+
+
+def test_group_lasso_drops_noise_across_all_tasks() -> None:
+    """The headline multi-task property: group-lasso across tasks zeros a
+    noise feature uniformly in *both* tasks, even though running each
+    task independently might leave a small spurious slope.
+    """
+    rng = np.random.default_rng(2)
+    n = 400
+    signal = rng.normal(size=n)
+    noise = rng.normal(size=n)
+    y1 = 1.5 * signal + 0.1 * rng.normal(size=n)
+    y2 = -0.8 * signal + 0.1 * rng.normal(size=n)
+    X = pd.DataFrame({"signal": signal, "noise": noise})
+
+    mt = MultiTaskGAM(families=["normal", "normal"])
+    mt.add_feature(
+        "signal",
+        type="linear",
+        regularization={"group_lasso_across_tasks": {"coef": 0.3}},
+    )
+    mt.add_feature(
+        "noise",
+        type="linear",
+        regularization={"group_lasso_across_tasks": {"coef": 0.3}},
+    )
+    mt.fit([X, X], [y1, y2], max_its=80)
+
+    sig = mt._features["signal"]
+    noi = mt._features["noise"]
+    assert abs(sig._m[0]) > 0.5
+    assert abs(sig._m[1]) > 0.3
+    # Both noise slopes must be exactly zero -- group-lasso prox zeros
+    # the entire K-vector, not each entry independently.
+    assert noi._m[0] == 0.0
+    assert noi._m[1] == 0.0
+
+
+def test_fit_mixed_normal_and_binomial() -> None:
+    """Per-task (family, link): one task normal+identity, one task
+    binomial+logit. Both should converge and predict in plausible ranges.
+    """
+    rng = np.random.default_rng(7)
+    n = 500
+    a = rng.normal(size=n)
+    b = rng.normal(size=n)
+    y_norm = 1.5 * a - 0.7 * b + 0.1 * rng.normal(size=n)
+    eta = 0.8 * a + 0.3 * b
+    y_bin = rng.binomial(1, special.expit(eta)).astype(float)
+    X = pd.DataFrame({"a": a, "b": b})
+
+    mt = MultiTaskGAM(families=["normal", "binomial"])
+    mt.add_feature("a", type="linear")
+    mt.add_feature("b", type="linear")
+    mt.fit([X, X], [y_norm, y_bin], max_its=120)
+
+    assert mt._fitted
+    # Task 0 (normal) recovers true slopes well.
+    assert mt._features["a"]._m[0] == pytest.approx(1.5, abs=0.05)
+    assert mt._features["b"]._m[0] == pytest.approx(-0.7, abs=0.05)
+    # Task 1 (binomial) slopes are in the right direction with
+    # plausible magnitudes (less precise because of the logit link).
+    assert mt._features["a"]._m[1] > 0.4
+    assert mt._features["b"]._m[1] > 0.0
+
+    preds = mt.predict(X)
+    assert preds[0].shape == (n,)
+    assert preds[1].shape == (n,)
+    # Binomial predictions live in (0, 1).
+    assert preds[1].min() > 0.0
+    assert preds[1].max() < 1.0
+
+
+def test_predict_accepts_per_task_dataframes() -> None:
+    """Passing a list of K DataFrames (each with its own rows) returns
+    K predictions of matching length.
+    """
+    Xs, ys, _ = _gen_two_task_normal(n1=100, n2=160, seed=5)
+    mt = MultiTaskGAM(families=["normal", "normal"])
+    mt.add_feature("a", type="linear")
+    mt.add_feature("b", type="linear")
+    mt.fit(Xs, ys, max_its=80)
+
+    Xt1 = pd.DataFrame({"a": np.linspace(-1, 1, 7), "b": np.zeros(7)})
+    Xt2 = pd.DataFrame({"a": np.zeros(13), "b": np.linspace(-2, 2, 13)})
+    preds = mt.predict([Xt1, Xt2])
+    assert preds[0].shape == (7,)
+    assert preds[1].shape == (13,)
+
+
+def test_deviance_matches_predict() -> None:
+    """``deviance(X, y)`` evaluated on training data should coincide
+    with the deviance computed from the iterate via
+    ``deviance()`` to within ADMM tolerance.
+    """
+    Xs, ys, _ = _gen_two_task_normal(seed=6)
+    mt = MultiTaskGAM(families=["normal", "normal"])
+    mt.add_feature("a", type="linear")
+    mt.add_feature("b", type="linear")
+    mt.fit(Xs, ys, max_its=200)
+
+    dev_internal = mt.deviance()
+    dev_external = mt.deviance(Xs, ys)
+    for k in range(2):
+        assert dev_internal[k] == pytest.approx(dev_external[k], rel=5e-3)
+
+
+def test_predict_before_fit_raises() -> None:
+    mt = MultiTaskGAM(families=["normal", "normal"])
+    mt.add_feature("a", type="linear")
+    X = pd.DataFrame({"a": np.array([0.0, 1.0])})
+    with pytest.raises(AttributeError, match="not yet fit"):
+        mt.predict([X, X])
+
+
+def test_summary_and_friends_raise_not_implemented() -> None:
+    """Single-task helpers we deliberately did not wire up should surface
+    a clear NotImplementedError in this slice.
+    """
+    mt = MultiTaskGAM(families=["normal", "normal"], name="mt")
+    for name in ("summary", "aic", "aicc"):
+        with pytest.raises(NotImplementedError):
+            getattr(mt, name)()
+    with pytest.raises(NotImplementedError):
+        mt.gcv()
+    with pytest.raises(NotImplementedError):
+        mt.ubre()
+    with pytest.raises(NotImplementedError):
+        mt.confidence_intervals()
+
+
+def test_unsupported_feature_type_raises() -> None:
+    mt = MultiTaskGAM(families=["normal", "normal"])
+    with pytest.raises(ValueError, match="not supported in this slice"):
+        mt.add_feature("a", type="categorical")  # type: ignore[arg-type]
+
+
+def test_fit_validates_input_lengths() -> None:
+    mt = MultiTaskGAM(families=["normal", "normal"])
+    mt.add_feature("a", type="linear")
+    X = pd.DataFrame({"a": np.array([0.0, 1.0, 2.0])})
+    y = np.array([0.0, 1.0, 2.0])
+    with pytest.raises(ValueError, match="must be a list of length 2"):
+        mt.fit([X], [y, y], max_its=10)  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="rows"):
+        mt.fit([X, X], [y, np.array([0.0, 1.0])], max_its=10)


### PR DESCRIPTION
Fits K supervised-learning tasks jointly under a shared feature set
with optional convex cross-task regularization. Per-task (family,
link), per-task n_k, and group-lasso-across-tasks coupling on linear
features. Coupling lives inside a new multi-task feature class so the
ADMM orchestrator never sees a penalty coefficient (CLAUDE.md seam
principle). Persistence, summary/plot, and other coupling penalties
are deferred follow-ups.

https://claude.ai/code/session_01Y4kn9QowUGk6kBTStuMs8o