### PR TITLE
Switch doc deploy to rsync push from CI

### DIFF
--- a/.github/workflows/deploy_docs.yml
+++ b/.github/workflows/deploy_docs.yml
@@ -3,19 +3,39 @@ on:
   push:
     branches: [master]
     paths:
-      - 'docs/**'   # only fire when docs change
+      - 'docs/**'
 
 jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-    - name: Pull docs on droplet
-      uses: appleboy/ssh-action@v1.2.5
-      with:
-        host: ${{ secrets.PROD_HOST }}
-        username: ${{ secrets.PROD_USERNAME }}
-        key: ${{ secrets.PROD_SSHKEY }}
-        script: |
-          set -e
-          cd nginx-proxy/convexanalytics/gamdist
-          git pull --ff-only
+      - uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v3
+        with:
+          enable-cache: true
+
+      - name: Set up Python
+        run: uv python install 3.12
+
+      - name: Install dependencies
+        run: uv sync --extra dev
+
+      - name: Build docs
+        run: cd docs && uv run make html
+
+      - name: Set up SSH key
+        run: |
+          mkdir -p ~/.ssh
+          chmod 700 ~/.ssh
+          printf '%s\n' "${{ secrets.DOCS_DEPLOY_KEY }}" > ~/.ssh/deploy_key
+          chmod 600 ~/.ssh/deploy_key
+          ssh-keyscan -H "${{ secrets.DOCS_HOST }}" >> ~/.ssh/known_hosts
+
+      - name: Deploy docs via rsync
+        run: |
+          rsync -az --delete \
+            -e "ssh -i ~/.ssh/deploy_key" \
+            docs/_build/html/ \
+            ${{ secrets.DOCS_USER }}@${{ secrets.DOCS_HOST }}:/srv/docs/convexanalytics/gamdist/.


### PR DESCRIPTION
## Summary

- Replaces the old SSH-pull-on-server pattern (`appleboy/ssh-action` + `git pull`) with a CI-driven rsync push
- On every push to `master` that touches `docs/**`: builds Sphinx HTML, then rsyncs `docs/_build/html/` to `/srv/docs/convexanalytics/gamdist/` on the droplet
- Three new repo secrets required before merging: `DOCS_DEPLOY_KEY` (private key), `DOCS_HOST`, `DOCS_USER`
- The deploy key will be jailed to the rsync target via `rrsync` on the server side — no broader filesystem access

## Test plan

- [ ] Droplet side: `/srv/docs/convexanalytics/gamdist/` target created, `rrsync` jail configured, public half of `DOCS_DEPLOY_KEY` installed
- [ ] Repo secrets `DOCS_DEPLOY_KEY`, `DOCS_HOST`, `DOCS_USER` added to rwilson4/gamdist
- [ ] Merge and confirm the workflow runs green and docs appear at the expected URL

**Do not merge until the droplet-side setup is confirmed ready.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)