### PR TITLE
Fix rsync destination for jailed deploy key

### DIFF
--- a/.github/workflows/deploy_docs.yml
+++ b/.github/workflows/deploy_docs.yml
@@ -38,4 +38,4 @@ jobs:
           rsync -az --delete \
             -e "ssh -i ~/.ssh/deploy_key" \
             docs/_build/html/ \
-            ${{ secrets.DOCS_USER }}@${{ secrets.DOCS_HOST }}:/srv/docs/convexanalytics/gamdist/.
+            ${{ secrets.DOCS_USER }}@${{ secrets.DOCS_HOST }}:


### PR DESCRIPTION
## Summary

- Changes the rsync destination from `:/srv/docs/convexanalytics/gamdist/.` to a bare trailing colon `:`
- With an rrsync-jailed key, supplying an absolute path causes rsync to interpret it relative to the jail root, nesting output under `.../gamdist/srv/docs/convexanalytics/gamdist/` — a 404
- The trailing colon tells rsync to use the connection root, which is the jail base (`/srv/docs/convexanalytics/gamdist/`) on the server side
- Side benefit: the workflow no longer encodes the droplet's filesystem layout; if the path moves, only `authorized_keys` changes

## Test plan

- [ ] `DOCS_DEPLOY_KEY` on rwilson4/gamdist updated to the jailed private key from droplet-Claude
- [ ] Merge → CI fires → droplet-Claude confirms jailed key fingerprint in auth log and docs land in `/srv/docs/convexanalytics/gamdist/` (not nested)
- [ ] Old `PROD_SSHKEY`, `PROD_HOST`, `PROD_USERNAME` secrets removed from rwilson4/gamdist

**Do not merge until `DOCS_DEPLOY_KEY` is updated to the jailed key.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)