### PR TITLE
Make _LinearFeature.dof() and _SplineFeature.dof() regularization-aware (#79)

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,32 @@
+2026-05-09 : Regularization-aware effective dof on linear and spline features (#79)
+- Closes the linear / spline slice of #79. Both features previously
+  reported a constant dof regardless of regularization; now:
+- _LinearFeature.dof(): unregularized = 1; L1 / group_lasso /
+  group_lasso_inf = 0 if the slope was soft-thresholded to zero, else
+  1; L2 = trace ``xtx / (xtx + lambda_2)``; Huber-in-L2-zone =
+  ``xtx / (xtx + lambda_2 + 0.5 * lambda_h)`` (the half-Huber
+  penalty's quadratic regime contributes 0.5 * lambda_h to the ridge
+  denominator); Huber-in-L1-zone falls back to the L2 formula. The
+  elastic-net (L1 + L2) case routes through the same trace formula
+  whenever the feature is active.
+- _SplineFeature.dof(): defaults to the curvature-penalty trace
+  ``self._dof`` (unchanged) but returns 0 when the group-lasso family
+  has zeroed the feature's *contribution* ``N theta``. The check is on
+  ``N theta``, not theta itself, because the group-lasso penalty acts
+  on ``||N theta||`` and theta can sit in the numerical null space of
+  N at large lambda.
+- Fixed a factor-of-2 bug in _CategoricalFeature's huber dof formula
+  introduced alongside #82: the half-Huber penalty has Hessian
+  `lambda` in the L2 zone, so the hat-matrix denominator picks up
+  ``0.5 * lambda``, not ``lambda``. Confirmed by the existing
+  test_huber_large_delta_matches_ridge parity (huber(coef=lam,
+  delta=inf) == ridge(coef=lam/2)) and a new analogous edof-parity
+  test in test_categorical_dof.py.
+- New tests/test_linear_dof.py (7 tests) and tests/test_spline_dof.py
+  (2 tests) pin the analytic limits and intermediate fits for each
+  regime. Existing 119-test linear / categorical / spline subset still
+  passes with no changes.
+
 2026-05-09 : Network-lasso choropleth guide refreshed for the new edof
 - Updated docs/user_guides/network_lasso_choropleth.rst to reflect the
   regularization-aware ``dof()`` from #79/#82. Headline lambda moved

--- a/gamdist/categorical_feature.py
+++ b/gamdist/categorical_feature.py
@@ -982,9 +982,15 @@ class _CategoricalFeature(_Feature):
             return float(max(edof - zero_sum_credit, 0.0))
 
         # Huber: per-category mix of L2 trace and L1 active-set count.
+        # The half-Huber penalty 0.5 * lambda * h_delta(q) has Hessian
+        # `lambda` in the L2 zone (cvxpy's huber returns q^2 there); the
+        # hat-matrix denominator therefore picks up `0.5 * lambda` once
+        # we factor out the leading 2 of the residual Hessian. (See the
+        # `test_huber_large_delta_matches_ridge` parity test, which
+        # confirms huber(coef=lam, delta=inf) == ridge(coef=lam/2).)
         if self._has_huber:
             in_l2 = np.abs(p) <= self._delta_huber
-            denom = ata_diag + self._lambda_huber_vec
+            denom = ata_diag + 0.5 * self._lambda_huber_vec
             denom = np.where(denom > 0, denom, 1.0)
             l2_part = np.where(in_l2, ata_diag / denom, 0.0).sum()
             l1_active = int(np.sum((~in_l2) & (np.abs(p) > 1e-8)))

--- a/gamdist/linear_feature.py
+++ b/gamdist/linear_feature.py
@@ -568,7 +568,45 @@ class _LinearFeature(_Feature):
         return 1
 
     def dof(self) -> float:
-        """Effective degrees of freedom contributed by this feature."""
+        r"""Effective degrees of freedom contributed by this feature.
+
+        The unregularized linear feature contributes one parameter (the
+        slope :math:`\beta`). Regularization shrinks the count:
+
+        - **L1 / group lasso / group_lasso_inf**: 0 if the slope was
+          soft-thresholded to zero, else 1.
+        - **L2 (ridge)**: trace of the hat matrix, which for the 1-D
+          design reduces to :math:`x^Tx / (x^Tx + \lambda_2)`. Tends
+          to 1 as :math:`\lambda_2 \to 0` and to 0 as
+          :math:`\lambda_2 \to \infty`.
+        - **Huber**: in the L2 zone (:math:`|m| \le \delta`), trace
+          :math:`x^Tx / (x^Tx + \lambda_2 + 0.5 \lambda_h)` -- the
+          half-Huber penalty's quadratic regime adds
+          :math:`0.5 \lambda_h` to the ridge denominator. In the L1
+          zone the huber term contributes only a linear shift, so the
+          denominator drops back to :math:`x^Tx + \lambda_2`.
+        - **Elastic net (L1 + L2)**: 0 if zeroed by L1, else
+          :math:`x^Tx / (x^Tx + \lambda_2)`.
+        """
+        # Soft-thresholded to zero by L1 / group lasso / group_lasso_inf.
+        if abs(self._m) < 1e-10 and (
+            self._has_l1 or self._has_group_lasso or self._has_group_lasso_inf
+        ):
+            return 0.0
+
+        # Trace formula whenever a quadratic-shrinkage term is active. L2
+        # contributes lambda_2; huber-in-L2-zone contributes 0.5 * lambda_h.
+        in_huber_l2 = self._has_huber and abs(self._m) <= self._delta_huber
+        if self._has_l2 or in_huber_l2:
+            denom = self._xtx
+            if self._has_l2:
+                denom += self._lambda2
+            if in_huber_l2:
+                denom += 0.5 * self._lambda_huber
+            if denom > 0.0:
+                return float(self._xtx / denom)
+
+        # Active feature with no quadratic shrinkage: edof = 1.
         return 1.0
 
     def predict(self, X: npt.NDArray[Any]) -> FloatArray:

--- a/gamdist/spline_feature.py
+++ b/gamdist/spline_feature.py
@@ -698,7 +698,27 @@ class _SplineFeature(_Feature):
         return len(self._theta)
 
     def dof(self) -> float:
-        """Effective degrees of freedom contributed by this feature."""
+        r"""Effective degrees of freedom contributed by this feature.
+
+        The spline's curvature penalty already shrinks the active
+        parameter count from ``num_knots`` toward 1; ``self._dof`` is
+        the trace of the smoother
+        :math:`(N^T N + \lambda \Omega)^{-1} N^T N` set at fit time.
+
+        The one regularization that operates on top of this and can
+        therefore reduce ``dof`` further is the group-lasso family
+        (``group_lasso`` / ``group_lasso_inf``), which zeros the
+        feature's contribution :math:`N\theta` once :math:`\lambda` is
+        large enough --- feature selection on a smooth function. The
+        penalties act on :math:`\|N\theta\|`, not on :math:`\theta`
+        directly, so :math:`\theta` itself can be non-tiny while
+        sitting in the (numerical) null space of :math:`N`; the check
+        is therefore on the fitted contribution, not :math:`\theta`.
+        """
+        if self._has_group_lasso or self._has_group_lasso_inf:
+            f_hat = self._N @ self._theta
+            if float(np.max(np.abs(f_hat))) < 1e-4:
+                return 0.0
         return float(self._dof)
 
     def predict(self, X: npt.NDArray[Any]) -> FloatArray:

--- a/tests/test_categorical_dof.py
+++ b/tests/test_categorical_dof.py
@@ -225,6 +225,31 @@ def test_full_gam_dispersion_uses_shrunk_dof_for_normal_family() -> None:
     assert phi > 0
 
 
+def test_huber_dof_matches_ridge_in_l2_limit() -> None:
+    # As delta -> infinity Huber collapses to 0.5 * lambda * q^2
+    # elementwise (cf. test_huber_large_delta_matches_ridge), i.e. ridge
+    # with strength lambda / 2. The corresponding edof must match too:
+    # at lambda_huber == 2 * n_c the L2-zone trace formula
+    # n_c / (n_c + 0.5 * lambda_h) gives 0.5 per category, so summed over
+    # K = 4 balanced categories minus the zero-sum constraint we expect 1.
+    regions = ["a", "b", "c", "d"]
+    x = _balanced_x(regions, 10)
+    fpumz = np.zeros(40)
+
+    feat = _CategoricalFeature(
+        name="g", regularization={"huber": {"coef": 20.0, "delta": 1e4}}
+    )
+    feat.initialize(x)
+    feat.optimize(fpumz, rho=1.0)
+    assert feat.dof() == pytest.approx(1.0, abs=1e-3)
+
+    # Parity: ridge with half the coef should land on the same edof.
+    ridge = _CategoricalFeature(name="g", regularization={"l2": {"coef": 10.0}})
+    ridge.initialize(x)
+    ridge.optimize(fpumz, rho=1.0)
+    assert feat.dof() == pytest.approx(ridge.dof(), abs=1e-6)
+
+
 def test_dispersion_raises_on_saturated_normal_model() -> None:
     rng = np.random.default_rng(7)
     regions = [f"r{i:02d}" for i in range(10)]

--- a/tests/test_linear_dof.py
+++ b/tests/test_linear_dof.py
@@ -1,0 +1,160 @@
+"""Tests for regularization-aware ``_LinearFeature.dof()``.
+
+The plain (unregularized) linear feature contributes one degree of
+freedom (the slope :math:`\\beta`). Adding a regularization term shrinks
+the *fitted* parameter count: ridge contracts the slope smoothly, L1
+and the group-lasso variants soft-threshold it to zero, and Huber
+straddles both regimes. These tests pin the analytic limits and an
+intermediate fit for each regime so the AIC / BIC / GCV chain that
+consumes ``dof()`` stays honest under regularization (issue #79).
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from gamdist.linear_feature import _LinearFeature
+
+
+def _balanced_x(n: int, seed: int = 0) -> np.ndarray:
+    rng = np.random.default_rng(seed)
+    return rng.normal(size=n)
+
+
+def test_unregularized_dof_is_one() -> None:
+    feat = _LinearFeature(name="x")
+    feat.initialize(_balanced_x(50))
+    feat.optimize(np.zeros(50), rho=1.0)
+    assert feat.dof() == pytest.approx(1.0)
+
+
+def test_l2_dof_shrinks_with_lambda() -> None:
+    # Closed-form trace: edof = xtx / (xtx + lambda_2). The feature
+    # internally centers x, so we read xtx from the initialized feature
+    # rather than computing it from the raw data:
+    #   lambda_2 = 0      ->  edof = 1
+    #   lambda_2 = xtx    ->  edof = 0.5
+    #   lambda_2 -> inf   ->  edof -> 0
+    rng = np.random.default_rng(0)
+    x = rng.normal(size=200)
+    fpumz = rng.normal(size=200)
+
+    f0 = _LinearFeature(name="x", regularization={"l2": {"coef": 1e-9}})
+    f0.initialize(x)
+    f0.optimize(fpumz, rho=1.0)
+    assert f0.dof() == pytest.approx(1.0, abs=1e-3)
+    xtx_centered = float(f0._xtx)
+
+    f_mid = _LinearFeature(name="x", regularization={"l2": {"coef": xtx_centered}})
+    f_mid.initialize(x)
+    f_mid.optimize(fpumz, rho=1.0)
+    assert f_mid.dof() == pytest.approx(0.5, abs=1e-6)
+
+    f_inf = _LinearFeature(name="x", regularization={"l2": {"coef": 1e12}})
+    f_inf.initialize(x)
+    f_inf.optimize(fpumz, rho=1.0)
+    assert f_inf.dof() == pytest.approx(0.0, abs=1e-6)
+
+
+def test_l1_dof_is_active_set() -> None:
+    rng = np.random.default_rng(1)
+    n = 200
+    x = rng.normal(size=n)
+    fpumz = rng.normal(size=n)
+
+    # Tiny lambda: feature stays active, dof = 1.
+    f_small = _LinearFeature(name="x", regularization={"l1": {"coef": 0.01}})
+    f_small.initialize(x)
+    f_small.optimize(fpumz, rho=1.0)
+    assert f_small.dof() == pytest.approx(1.0)
+
+    # Huge lambda: slope soft-thresholded to zero.
+    f_huge = _LinearFeature(name="x", regularization={"l1": {"coef": 1e6}})
+    f_huge.initialize(x)
+    f_huge.optimize(fpumz, rho=1.0)
+    assert f_huge._m == pytest.approx(0.0, abs=1e-12)
+    assert f_huge.dof() == pytest.approx(0.0)
+
+
+def test_group_lasso_dof_is_active_set() -> None:
+    rng = np.random.default_rng(2)
+    n = 200
+    x = rng.normal(size=n)
+    fpumz = rng.normal(size=n)
+
+    f_small = _LinearFeature(name="x", regularization={"group_lasso": {"coef": 0.001}})
+    f_small.initialize(x)
+    f_small.optimize(fpumz, rho=1.0)
+    assert f_small.dof() == pytest.approx(1.0)
+
+    f_huge = _LinearFeature(name="x", regularization={"group_lasso": {"coef": 1e6}})
+    f_huge.initialize(x)
+    f_huge.optimize(fpumz, rho=1.0)
+    assert f_huge._m == pytest.approx(0.0, abs=1e-12)
+    assert f_huge.dof() == pytest.approx(0.0)
+
+
+def test_elastic_net_dof_uses_ridge_trace_when_active() -> None:
+    # L1 + L2: when active the trace formula falls back to the L2 piece
+    # (the L1 part shrinks the value of m but doesn't change the active
+    # Hessian). Match xtx / (xtx + lambda_2).
+    rng = np.random.default_rng(3)
+    n = 200
+    x = rng.normal(size=n)
+    fpumz = rng.normal(size=n) + 5.0  # bias makes the active solution likely
+
+    pilot = _LinearFeature(name="x")
+    pilot.initialize(x)
+    xtx = float(pilot._xtx)
+
+    feat = _LinearFeature(
+        name="x",
+        regularization={"l1": {"coef": 0.1}, "l2": {"coef": xtx}},
+    )
+    feat.initialize(x)
+    feat.optimize(fpumz, rho=1.0)
+    assert abs(feat._m) > 1e-6
+    assert feat.dof() == pytest.approx(0.5, abs=1e-6)
+
+
+def test_huber_in_l2_zone_dof_uses_half_lambda() -> None:
+    # When |m| <= delta the half-Huber penalty 0.5 * lambda_h * h(m) is
+    # locally 0.5 * lambda_h * m^2, i.e. ridge with strength
+    # 0.5 * lambda_h. The hat-matrix denominator therefore picks up
+    # 0.5 * lambda_h, and at lambda_h = 2 * xtx the trace must be 0.5.
+    rng = np.random.default_rng(4)
+    n = 200
+    x = rng.normal(size=n)
+    fpumz = rng.normal(size=n) * 0.001  # small target -> |m| stays small
+
+    pilot = _LinearFeature(name="x")
+    pilot.initialize(x)
+    xtx = float(pilot._xtx)
+
+    feat = _LinearFeature(
+        name="x",
+        regularization={"huber": {"coef": 2.0 * xtx, "delta": 1e6}},
+    )
+    feat.initialize(x)
+    feat.optimize(fpumz, rho=1.0)
+    assert abs(feat._m) <= feat._delta_huber  # in the L2 zone
+    assert feat.dof() == pytest.approx(0.5, abs=1e-6)
+
+
+def test_huber_in_l1_zone_dof_falls_back_to_one() -> None:
+    # When |m| > delta the huber term is linear and the trace formula
+    # collapses to xtx/(xtx + lambda_2). With no L2 component, that's 1.
+    rng = np.random.default_rng(5)
+    n = 200
+    x = rng.normal(size=n)
+    fpumz = rng.normal(size=n) + 50.0  # large target -> |m| likely > delta
+
+    feat = _LinearFeature(
+        name="x",
+        regularization={"huber": {"coef": 0.1, "delta": 0.001}},
+    )
+    feat.initialize(x)
+    feat.optimize(fpumz, rho=1.0)
+    assert abs(feat._m) > feat._delta_huber  # in the L1 zone
+    assert feat.dof() == pytest.approx(1.0, abs=1e-6)

--- a/tests/test_spline_dof.py
+++ b/tests/test_spline_dof.py
@@ -1,0 +1,63 @@
+"""Tests for ``_SplineFeature.dof()`` under group-lasso selection.
+
+The spline feature already shrinks the active parameter count via the
+curvature penalty (``self._dof`` is the trace of the smoother set at
+fit time). Group-lasso on top of that is feature-selection: when the
+penalty is large enough to zero the entire coefficient vector, ``dof``
+must drop to 0 to reflect that the feature is no longer in the model
+(issue #79).
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from gamdist import GAM
+
+
+def test_spline_group_lasso_zeroed_dof_is_zero() -> None:
+    # Pure-noise signal; very large group-lasso coef forces the spline
+    # coefficients to zero.
+    rng = np.random.default_rng(0)
+    n = 300
+    x = rng.uniform(0.0, 1.0, size=n)
+    y = rng.normal(scale=0.01, size=n)
+
+    mdl = GAM(family="normal")
+    mdl.add_feature(
+        name="x",
+        type="spline",
+        regularization={"group_lasso": {"coef": 1e3}},
+    )
+    mdl.fit(pd.DataFrame({"x": x}), y, max_its=40)
+
+    feat = mdl._features["x"]
+    # group_lasso penalizes ||N theta||, not theta directly, so theta
+    # can be non-tiny while sitting in the null space of N. The
+    # right "zeroed" check is on the predicted contribution.
+    np.testing.assert_allclose(feat.predict(x), 0.0, atol=1e-4)
+    assert feat.dof() == pytest.approx(0.0)
+
+
+def test_spline_group_lasso_active_dof_matches_curvature_dof() -> None:
+    # Strong signal; small group-lasso coef leaves the spline active.
+    # In that case dof() should match the curvature-penalty trace
+    # (``self._dof`` set at initialize time).
+    rng = np.random.default_rng(1)
+    n = 400
+    x = np.sort(rng.uniform(0.0, 1.0, size=n))
+    y = np.sin(2.0 * np.pi * x) + 0.05 * rng.normal(size=n)
+
+    mdl = GAM(family="normal")
+    mdl.add_feature(
+        name="x",
+        type="spline",
+        regularization={"group_lasso": {"coef": 0.001}},
+    )
+    mdl.fit(pd.DataFrame({"x": x}), y, max_its=40)
+
+    feat = mdl._features["x"]
+    assert float(np.max(np.abs(feat._theta))) > 0.1
+    assert feat.dof() == pytest.approx(feat._dof)


### PR DESCRIPTION
## Summary

Closes the linear / spline slice of #79 (#82 covered `_CategoricalFeature`).

### `_LinearFeature.dof()`

| Penalty | Formula |
|---|---|
| Unregularized | `1` |
| `l1` / `group_lasso` / `group_lasso_inf` | 0 if soft-thresholded to zero, else 1 |
| `l2` (ridge) | `xtx / (xtx + λ_2)` |
| `huber` in L2 zone (`|m| ≤ δ`) | `xtx / (xtx + λ_2 + 0.5 · λ_h)` |
| `huber` in L1 zone (`|m| > δ`) | `xtx / (xtx + λ_2)` (huber's L1 term is linear, no Hessian contribution) |
| Elastic net (`l1` + `l2`) | trace formula whenever active, 0 if zeroed |

### `_SplineFeature.dof()`

Defaults to the curvature-penalty trace `self._dof` (the existing behavior is correct in the no-group-lasso case). Returns 0 when `group_lasso` / `group_lasso_inf` has zeroed the feature's contribution. **The check is on `N θ`, not `θ` itself** — the group-lasso penalty acts on `‖N θ‖`, so at large λ `θ` can sit in the numerical null space of `N` while the predicted contribution is essentially zero.

### Drive-by fix: categorical huber dof factor-of-2

While reviewing the linear-feature derivation I noticed `_CategoricalFeature.dof()` was computing the huber denominator as `n_c + λ_h` instead of `n_c + 0.5 · λ_h` (the half-Huber's L2 zone has Hessian `λ_h`, not `2 λ_h`). This is internally consistent now: the existing `test_huber_large_delta_matches_ridge` confirms that `huber(coef=lam, delta=∞)` matches `ridge(coef=lam/2)`, and a new analogous edof-parity test pins the equivalent dof.

## Test plan

- [x] New `tests/test_linear_dof.py` (7 tests) covers L2 limits, L1/group-lasso active-vs-zeroed, elastic net, and both huber zones.
- [x] New `tests/test_spline_dof.py` (2 tests) covers active and zeroed group-lasso.
- [x] Updated `tests/test_categorical_dof.py` adds `test_huber_dof_matches_ridge_in_l2_limit` for the factor-of-2 fix.
- [x] All 20 dof tests pass.
- [x] 119-test regression subset (linear / categorical / spline / huber / group-lasso / network-ridge files) passes with no changes.
- [x] `ruff check`, `ruff format --check`, `mypy gamdist`: clean.

#79 was 3-pronged (categorical + linear + spline); after this lands all three are addressed and the issue can close.

https://claude.ai/code/session_01QoNPYdeBfvNYFfVSW3ofic

---
_Generated by [Claude Code](https://claude.ai/code/session_01QoNPYdeBfvNYFfVSW3ofic)_